### PR TITLE
fix: throw error from apiPlugin instead of exit

### DIFF
--- a/src/plugins/apiRoutes.js
+++ b/src/plugins/apiRoutes.js
@@ -66,8 +66,7 @@ const apiRoutesPlugin = {
                     'Running without authentication requires to setup mapping to a user to use for requests requiring a current user id (e.g. creating apps for example). Set process.env.NO_AUTH_MAPPED_USER_ID',
                     '\x1b[m'
                 )
-                process.exit(1)
-                return
+                throw new Error("No auth set up. Set process.env.NO_AUTH_MAPPED_USER_ID to a valid user ID.")
             }
         }
 


### PR DESCRIPTION
Plugins should not call System.exit(). When running tests without `NO_AUTH_MAPPED_USER_ID` I did not get an error, the tests just exit as debug are not shown in tests, which was very confusing. To me it makes much more sense to throw an error here, which also crashes the app.