### PR TITLE
feat: organisation services

### DIFF
--- a/src/models/v2/Default.js
+++ b/src/models/v2/Default.js
@@ -1,0 +1,60 @@
+const joi = require('@hapi/joi')
+
+/*
+    The default base definition of an entity.
+    This can be used to validate and transform an object using joi.validate()
+    or joi.attempt.
+
+    Other definitions can inherit and add to this this by .append()
+    Any renames and transformations are from database -> internal.
+    So an object validated directly by this definition are expected to be of
+    database shape, and results in an internal-model.
+
+    Any unknown keys are removed.
+
+    Note that all fields are optional by default.
+    This is by design, as we do not want to enforce all database-queries
+    to include every field.
+    The idea is that all validations and transformation use this as a base.
+    This way we have one place to update the type if anything were to change.
+    Using defintion.extract() we can grab the base field and build upon it with eg. .required()
+
+*/
+
+const definition = joi
+    .object()
+    .keys({
+        id: joi.string().guid({ version: 'uuidv4' }),
+        updatedAt: joi
+            .date()
+            .cast('number')
+            .allow(null),
+        createdAt: joi.date().cast('number'),
+    })
+    .rename('updated_at', 'updatedAt', { ignoreUndefined: true })
+    .rename('created_at', 'createdAt', { ignoreUndefined: true })
+    .prefs({
+        stripUnknown: true,
+    })
+
+/**
+ * Creates a default function to validating
+ * and transform results the given definition (a joi schema).
+ * @param {Joi.Schema} defintion - The joi schema to use
+ *
+ * @returns {function(dbResult): []} - A function taking some data (may be an array or object) to be validated by the schema.
+ * The function throws a ValidationError if mapping fails
+ */
+function createDefaultValidator(schema) {
+    return function(dbResult) {
+        return Array.isArray(dbResult)
+            ? dbResult.map(v => joi.attempt(v, schema))
+            : joi.attempt(dbResult, schema)
+    }
+}
+
+module.exports = {
+    def: definition,
+    definition,
+    createDefaultValidator,
+}

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -1,0 +1,55 @@
+const joi = require('@hapi/joi')
+const User = require('./User')
+const {
+    definition: defaultDefinition,
+    createDefaultValidator,
+} = require('./Default')
+
+const definition = defaultDefinition
+    .append({
+        name: joi.string(),
+        slug: joi.string(),
+        owner: joi.string().guid({ version: 'uuidv4' }),
+        users: joi.array().items(User.definition),
+    })
+    .alter({
+        db: s =>
+            s
+                .append({
+                    created_by_user_id: joi
+                        .string()
+                        .guid({ version: 'uuidv4' }),
+                })
+                .rename('owner', 'created_by_user_id'),
+    })
+    .rename('created_by_user_id', 'owner', {
+        ignoreUndefined: true,
+    })
+
+const defWithUsers = definition.append({
+    users: joi
+        .array()
+        .items(User.definition)
+        .required(),
+})
+
+const dbDefinition = definition.tailor('db')
+
+// internal -> external
+const externalDefintion = definition.tailor('external')
+
+// database -> internal
+const parseDatabaseJson = createDefaultValidator(definition)
+
+// internal -> database
+const formatDatabaseJson = createDefaultValidator(dbDefinition)
+
+module.exports = {
+    def: definition,
+    definition,
+    dbDefinition,
+    externalDefintion,
+    defWithUsers,
+    parseDatabaseJson,
+    formatDatabaseJson,
+}

--- a/src/models/v2/User.js
+++ b/src/models/v2/User.js
@@ -1,0 +1,18 @@
+const joi = require('@hapi/joi')
+const {
+    definition: defaultDefinition,
+    createDefaultValidator,
+} = require('./Default')
+
+const definition = defaultDefinition.append({
+    name: joi.string(),
+    email: joi.string(),
+})
+
+const parseDatabaseJson = createDefaultValidator(definition)
+
+module.exports = {
+    def: definition,
+    definition,
+    parseDatabaseJson,
+}

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -1,3 +1,3 @@
 const { flatten } = require('../../utils')
 
-module.exports = [require('./apps.js'), require('./channels.js')]
+module.exports = [require('./apps.js'), require('./channels.js'), require('./organisations')]

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -1,0 +1,265 @@
+const Boom = require('@hapi/boom')
+const Joi = require('@hapi/joi')
+const {
+    canCreateApp,
+    getCurrentAuthStrategy,
+    getCurrentUserFromRequest,
+} = require('../../security')
+const getUserByEmail = require('../../data/getUserByEmail')
+const { Organisation } = require('../../services')
+const OrgModel = require('../../models/v2/Organisation')
+
+module.exports = [
+    {
+        method: 'GET',
+        path: '/v2/organisations',
+        config: {
+            tags: ['api', 'v2'],
+            response: {
+                schema: Joi.array().items(OrgModel.externalDefintion),
+                modify: true,
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+
+            //get all orgs, no filtering
+            //TODO: add filtering
+            const orgs = await Organisation.find({}, h.context.db)
+            return orgs
+        },
+    },
+    {
+        method: 'GET',
+        path: '/v2/organisations/{orgId}',
+        config: {
+            auth: 'token',
+            validate: {
+                params: Joi.object({
+                    orgId: OrgModel.definition.extract('id').required(),
+                }),
+            },
+            tags: ['api', 'v2'],
+            response: {
+                schema: OrgModel.externalDefintion,
+                modify: true,
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { orgId } = request.params
+            const organisation = await Organisation.findOne(orgId, true, db)
+            return organisation
+        },
+    },
+    {
+        method: 'POST',
+        path: '/v2/organisations',
+        config: {
+            auth: 'token',
+            validate: {
+                payload: Joi.object({
+                    name: OrgModel.definition.extract('name').required(),
+                }),
+            },
+            tags: ['api', 'v2'],
+            response: {
+                schema: OrgModel.externalDefintion,
+                modify: true,
+            },
+        },
+
+        handler: async (request, h) => {
+            const { db } = h.context
+
+            const { id: userId } = await getCurrentUserFromRequest(request, db)
+
+            const createOrgAndAddUser = async trx => {
+                const organisation = await Organisation.create(
+                    { userId, name: request.payload.name },
+                    trx
+                )
+                const query = await Organisation.addUserById(
+                    organisation.id,
+                    userId,
+                    trx
+                )
+                return organisation
+            }
+
+            const organisation = await db.transaction(createOrgAndAddUser)
+
+            return h
+                .response(organisation)
+                .created(`/v2/organisations/${organisation.id}`)
+        },
+    },
+    {
+        method: 'PATCH',
+        path: '/v2/organisations/{orgId}',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+            validate: {
+                payload: Joi.object({
+                    name: OrgModel.definition.extract('name'),
+                    owner: OrgModel.definition.extract('owner'),
+                }),
+                params: Joi.object({
+                    orgId: OrgModel.definition.extract('id').required(),
+                }),
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id: userId } = await getCurrentUserFromRequest(request, db)
+
+            const updateObj = request.payload
+
+            const updateOrganisation = async trx => {
+                const organisation = await Organisation.findOne(
+                    request.params.orgId,
+                    false,
+                    trx
+                )
+                if (organisation.owner !== userId) {
+                    throw Boom.forbidden(
+                        'You do not have permissions to update this organisation'
+                    )
+                }
+                await Organisation.update(organisation.id, updateObj, db)
+                return {
+                    id: organisation.id,
+                }
+            }
+
+            const transaction = await db.transaction(updateOrganisation)
+            return h.response(transaction).code(200)
+        },
+    },
+    {
+        method: 'POST',
+        path: '/v2/organisations/{orgId}/user',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+            validate: {
+                payload: Joi.object({
+                    email: Joi.string()
+                        .email()
+                        .required(),
+                }),
+                params: Joi.object({
+                    orgId: OrgModel.definition.extract('id').required(),
+                }),
+            },
+            // response: {
+            //     status: {
+            //         //TODO: add response statuses
+            //     },
+            // },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id } = await getCurrentUserFromRequest(request, db)
+
+            const addUserToOrganisation = async trx => {
+                const org = await Organisation.findOne(
+                    request.params.orgId,
+                    true,
+                    trx
+                )
+
+                const isMember = org.users.findIndex(u => u.id === id) > -1
+                const canAdd = org.owner === id || isMember
+
+                if (!canAdd) {
+                    throw Boom.forbidden(
+                        'You do not have permission to add users'
+                    )
+                }
+
+                const userToAdd = await getUserByEmail(
+                    request.payload.email,
+                    trx
+                )
+                if (userToAdd && userToAdd.id) {
+                    await Organisation.addUserById(org.id, userToAdd.id, trx)
+                    return userToAdd
+                } else {
+                    throw Boom.conflict(`User with email not found.`)
+                }
+            }
+
+            const transaction = await db.transaction(addUserToOrganisation)
+
+            return {
+                statusCode: 200,
+            }
+        },
+    },
+    {
+        method: 'DELETE',
+        path: '/v2/organisations/{orgId}/user',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+            validate: {
+                payload: Joi.object({
+                    user: OrgModel.definition.extract('id').required(),
+                }),
+                params: Joi.object({
+                    orgId: OrgModel.definition.extract('id').required(),
+                }),
+            },
+            // response: {
+            //     status: {
+            //         //TODO: add response statuses
+            //     },
+            // },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id } = await getCurrentUserFromRequest(request, db)
+
+            const userIdToRemove = request.payload.user
+
+            const removeUserFromOrganisation = async trx => {
+                const org = await Organisation.findOne(
+                    request.params.orgId,
+                    true,
+                    trx
+                )
+                const isMember = org.users.findIndex(u => u.id === id) > -1
+                const canRemove = org.owner === id || isMember
+
+                if (org.owner === userIdToRemove) {
+                    throw Boom.conflict(
+                        'Cannot remove the owner of the organisation'
+                    )
+                }
+                if (!canRemove) {
+                    throw Boom.forbidden(
+                        'You do not have permission to remove users'
+                    )
+                }
+                const deletedRes = await Organisation.removeUser(
+                    org.id,
+                    userIdToRemove,
+                    trx
+                )
+                if (deletedRes < 1) {
+                    throw Boom.conflict(
+                        'User not found or not a member of organisation'
+                    )
+                }
+            }
+
+            const transaction = await db.transaction(removeUserFromOrganisation)
+
+            return {
+                statusCode: 200,
+            }
+        },
+    },
+]

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    Organisation: require('./organisation'),
+}

--- a/src/services/organisation.js
+++ b/src/services/organisation.js
@@ -1,0 +1,147 @@
+const Joi = require('@hapi/joi')
+const slugify = require('slugify')
+const { applyFiltersToQuery } = require('../utils/databaseUtils')
+const { NotFoundError } = require('../utils/errors')
+const User = require('../models/v2/User')
+const Organisation = require('../models/v2/Organisation')
+
+const getOrganisationQuery = db =>
+    db('organisation').select(
+        'organisation.id',
+        'organisation.name',
+        'organisation.slug',
+        'organisation.created_by_user_id'
+    )
+
+/**
+ * Creates an organisation.
+ *
+ * Note that this does not add the user to the organisation
+ * TODO: should this add the user, or is that up to the handler?
+ * @param object data
+ * @param {string} data.userId User id creating the data
+ * @param {*} db
+ */
+const create = async ({ userId, name }, db) => {
+    const slug = await ensureUniqueSlug(slugify(name, { lower: true }), db)
+    const obj = {
+        owner: userId,
+        name,
+        slug,
+    }
+    const dbData = Organisation.formatDatabaseJson(obj)
+    const [organisation] = await db('organisation')
+        .insert(dbData)
+        .returning(['id'])
+
+    return Organisation.parseDatabaseJson(organisation)
+}
+
+const ensureUniqueSlug = async (originalSlug, db) => {
+    let slug = originalSlug
+    let slugUniqueness = 2
+    let foundUniqueSlug = false
+    while (!foundUniqueSlug) {
+        const [{ count }] = await db('organisation')
+            .count('id')
+            .where('slug', slug)
+        if (count > 0) {
+            slug = `${originalSlug}-${slugUniqueness}`
+            slugUniqueness++
+        } else {
+            foundUniqueSlug = true
+        }
+    }
+
+    return slug
+}
+
+const find = async ({ filter, paging }, db) => {
+    const query = getOrganisationQuery(db)
+
+    if (filter) {
+        // special filter for gettings orgs for a particular user
+        if (filter.user) {
+            const userOrganisations = db('user_organisation')
+                .select('organisation_id')
+                .innerJoin('users', 'user_organisation.user_id', 'users.id')
+                .where('users.id', filter.user)
+
+            query.whereIn('organisation.id', userOrganisations)
+            delete filter.user
+        }
+        applyFiltersToQuery(filter, query, { tableName: 'organisation' })
+    }
+    const res = await query
+    const parsed = Organisation.parseDatabaseJson(res)
+
+    return parsed
+}
+
+const findOne = async (id, includeUsers = false, db) => {
+    const organisation = await getOrganisationQuery(db)
+        .first()
+        .where('organisation.id', id)
+    if (!organisation) {
+        throw new NotFoundError(`Organisation not found`)
+    }
+
+    const internalOrg = Organisation.parseDatabaseJson(organisation)
+
+    if (includeUsers) {
+        const users = await db('users')
+            .select('users.id', 'users.email', 'users.name')
+            .innerJoin(
+                'user_organisation',
+                'users.id',
+                'user_organisation.user_id'
+            )
+            .where('user_organisation.organisation_id', organisation.id)
+        internalOrg.users = User.parseDatabaseJson(users)
+    }
+
+    return internalOrg
+}
+
+const update = async (id, updateData, db) => {
+    const dbData = Organisation.formatDatabaseJson(updateData)
+
+    return db('organisation')
+        .update(dbData)
+        .where({ id })
+}
+
+const addUserById = async (id, userId, db) => {
+    const query = await db('user_organisation').insert({
+        user_id: userId,
+        organisation_id: id,
+    })
+
+    return query
+}
+
+const removeUser = async (id, userId, db) => {
+    const query = await db('user_organisation')
+        .where({
+            user_id: userId,
+            organisation_id: id,
+        })
+        .del()
+
+    return query
+}
+const remove = async (id, db) => {
+    await db('organisation')
+        .where({ id })
+        .delete()
+}
+
+module.exports = {
+    find,
+    findOne,
+    addUserById,
+    create,
+    update,
+    remove,
+    removeUser,
+}

--- a/src/utils/databaseUtils.js
+++ b/src/utils/databaseUtils.js
@@ -1,0 +1,18 @@
+
+function applyFiltersToQuery(filters, query, { tableName, columnMap }) {
+    for (k in filters) {
+        const colName = columnMap ? columnMap[k] : k
+        if (colName) {
+            query.where(
+                tableName ? `${tableName}.${colName}` : colName,
+                '=',
+                filters[k]
+            )
+        }
+    }
+    return
+}
+
+module.exports = {
+    applyFiltersToQuery
+}

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,10 @@
+class NotFoundError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'NotFoundError';
+    }   
+}
+
+module.exports = {
+    NotFoundError
+}

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -1,0 +1,292 @@
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const {
+    it,
+    describe,
+    afterEach,
+    beforeEach,
+    before,
+    after,
+} = (exports.lab = Lab.script())
+
+const knexConfig = require('../../../knexfile')
+const db = require('knex')(knexConfig)
+const { init } = require('../../../src/server/init-server')
+const { config } = require('../../../src/server/env-config')
+const { Organisation } = require('../../../src/services')
+const OrgMocks = require('../../../seeds/mock/organisations')
+const UserMocks = require('../../../seeds/mock/users')
+
+describe('v2/organisations', () => {
+    let server
+
+    before(async () => {
+        config.auth.noAuthUserIdMapping = UserMocks[0].id
+    })
+
+    beforeEach(async () => {
+        server = await init(db, config)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+    })
+
+    describe('get organisation', () => {
+        it('should get all organisations', async () => {
+            const opts = {
+                method: 'GET',
+                url: '/api/v2/organisations',
+            }
+
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+
+            const orgs = JSON.parse(res.payload)
+            expect(orgs).to.be.an.array()
+            expect(orgs[0]).to.include(['id', 'name', 'slug', 'owner'])
+        })
+
+        it('should get one organisation by id', async () => {
+            const dhis2Org = OrgMocks[0]
+            const request = {
+                method: 'GET',
+                url: `/api/v2/organisations/${dhis2Org.id}`,
+            }
+
+            const res = await server.inject(request)
+            const payload = JSON.parse(res.payload)
+            expect(payload).to.be.an.object()
+            expect(payload).to.include(['id', 'name', 'slug', 'owner', 'users'])
+        })
+    })
+
+    describe('create organisation', async () => {
+        it('should create successfully', async () => {
+            const orgName = 'HISP Tanzania'
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/organisations',
+                payload: {
+                    name: orgName,
+                },
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(201)
+            const payload = JSON.parse(res.payload)
+            expect(payload).to.include(['id'])
+            expect(payload.id).to.be.string()
+        })
+
+        it('should add the user to the newly added org', async () => {
+            const userId = config.auth.noAuthUserIdMapping
+            const orgName = 'HISP Uganda'
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/organisations',
+                payload: {
+                    name: orgName,
+                },
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(201)
+            const payload = JSON.parse(res.payload)
+            expect(payload).to.include(['id'])
+            expect(payload.id).to.be.string()
+
+            const request = {
+                method: 'GET',
+                url: `/api/v2/organisations/${payload.id}`,
+            }
+
+            const orgRes = await server.inject(request)
+            const orgPayload = JSON.parse(orgRes.payload)
+            expect(orgPayload).to.be.an.object()
+            expect(orgPayload.id).to.be.equal(payload.id)
+            expect(orgPayload.name).to.be.equal(orgName)
+            expect(orgPayload.users).to.be.an.array()
+            expect(orgPayload.users).to.have.length(1)
+            expect(orgPayload.users[0].id).to.be.equal(userId)
+        })
+
+        it('should fail if no payload', async () => {
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/organisations',
+                payload: {},
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(400)
+        })
+    })
+
+    describe('update organisation', () => {
+        it('should update name successfully', async () => {
+            const org = OrgMocks[0]
+            const request = {
+                method: 'PATCH',
+                url: `/api/v2/organisations/${org.id}`,
+                payload: {
+                    name: 'D2',
+                },
+            }
+            const res = await server.inject(request)
+            expect(res.statusCode).to.equal(200)
+            expect(res.result).to.be.an.object()
+            expect(res.result).to.include(['id'])
+            const updatedOrg = await Organisation.findOne(org.id, false, db)
+            expect(updatedOrg.name).to.equal('D2')
+
+            // reset name
+            await Organisation.update(org.id, { name: 'DHIS2' }, db)
+        })
+
+        it('should throw 400: Bad Request when payload is missing', async () => {
+            const org = OrgMocks[1]
+            const request = {
+                method: 'PATCH',
+                url: `/api/v2/organisations/${org.id}`,
+            }
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(400)
+        })
+    })
+
+    describe('add user to organisation', () => {
+        it('should add user successfully', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'HISP Tanzania' } },
+                db
+            )
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.id).to.be.a.string()
+
+            const opts = {
+                method: 'POST',
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
+                payload: {
+                    email: 'viktor@dhis2.org',
+                },
+            }
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+        })
+
+        it('should return 409 conflict if user does not exists', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.id).to.be.a.string()
+
+            const opts = {
+                method: 'POST',
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
+                payload: {
+                    email: 'example-fail@dhis2.org',
+                },
+            }
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(409)
+        })
+    })
+
+    describe('remove user from organisation', () => {
+        it('should remove successfully', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            const userToDelete = UserMocks[2] //viktor, DHIS2
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.id).to.be.a.string()
+
+            const opts = {
+                method: 'DELETE',
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
+                payload: {
+                    user: userToDelete.id,
+                },
+            }
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+        })
+
+        it('should return conflict when user is the creator', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            const userToDelete = UserMocks[0] //appphub
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.id).to.be.a.string()
+
+            const opts = {
+                method: 'DELETE',
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
+                payload: {
+                    user: userToDelete.id,
+                },
+            }
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(409)
+            expect(res.result.message).to.be.equal(
+                'Cannot remove the owner of the organisation'
+            )
+        })
+
+        it('should return conflict when user does not exist', async () => {
+            const userToDelete = '72bced64-c7f7-4b70-aa09-9b8d1e59ed49'
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            const opts = {
+                method: 'DELETE',
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
+                payload: {
+                    user: userToDelete,
+                },
+            }
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(409)
+            expect(res.result.message).to.be.equal(
+                'User not found or not a member of organisation'
+            )
+        })
+
+        it('should return 404: not found when organisation does not exist', async () => {
+            // TODO: this should be enabled only when errormapper-plugin is merged
+            return
+            const orgId = '72bced64-c7f7-4b70-aa09-9b8d1e59ed49'
+            const userToDelete = UserMocks[0] //appphub
+
+            const opts = {
+                method: 'DELETE',
+                url: `/api/v2/organisations/${orgId}/user`,
+                payload: {
+                    user: userToDelete.id,
+                },
+            }
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(409)
+            expect(res.result.message).to.be.equal('Organisation not found')
+        })
+    })
+})

--- a/test/services/organisation.js
+++ b/test/services/organisation.js
@@ -1,0 +1,318 @@
+const { expect } = require('@hapi/code')
+
+const Lab = require('@hapi/lab')
+
+const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
+
+const knexConfig = require('../../knexfile')
+const db = require('knex')(knexConfig)
+const getUserByEmail = require('../../src/data/getUserByEmail')
+
+const { ImageType } = require('../../src/enums')
+const { Organisation } = require('../../src/services')
+const UserMocks = require('../../seeds/mock/users')
+const OrganisationMocks = require('../../seeds/mock/organisations')
+
+describe('@services::Organisation', () => {
+    describe('find', () => {
+        it('should find by name filter', async () => {
+            const filter = {
+                name: 'DHIS2',
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(orgs.length).to.be.equal(1)
+            expect(DHIS2App).to.not.be.null()
+        })
+
+        it('should find all organisations without a specified filter', async () => {
+            const orgs = ['DHIS2', 'World Health Organization']
+            const dbOrgs = await Organisation.find({}, db)
+            orgs.forEach(org => {
+                const dbOrg = dbOrgs.find(o => o.name === org.name)
+                expect(dbOrg).to.not.be.null()
+            })
+        })
+
+        it('should find organisations by user if filter has user', async () => {
+            const user = await getUserByEmail('apphub-api@dhis2.org', db)
+            const filter = {
+                user: user.id,
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(DHIS2App).to.not.be.null()
+        })
+
+        it('should work with multiple filters, ie user and name', async () => {
+            const user = await getUserByEmail('apphub-api@dhis2.org', db)
+            const filter = {
+                name: 'DHIS2',
+                user: user.id,
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(DHIS2App).to.not.be.null()
+        })
+    })
+
+    describe('findOne', () => {
+        it('should throw if no existing id', async () => {
+            const org = Organisation.findOne(
+                'caacbb8c-01b4-4f98-8839-4aafafd46fee',
+                false,
+                db
+            )
+            await expect(org).to.reject()
+        })
+
+        it('should find organisations by id with users', async () => {
+            const orgs = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(orgs).to.have.length(1)
+            const dhis2Org = orgs[0]
+            expect(dhis2Org).to.not.be.null()
+            expect(dhis2Org.name).to.be.equal('DHIS2')
+            expect(dhis2Org.id).to.be.string()
+
+            const orgById = await Organisation.findOne(dhis2Org.id, true, db)
+            expect(orgById).to.not.be.null()
+            expect(orgById.users).to.be.an.array()
+            const members = ['Mr Jenkins']
+            members.forEach(name => {
+                const member = orgById.users.find(u => u.name === name)
+                expect(member).to.not.be.undefined()
+                expect(member.id).to.be.a.string()
+            })
+        })
+    })
+
+    describe('addUserById', async () => {
+        it('should successfully add user to organisation', async () => {
+            const userId = UserMocks[1].id //Erik, in WHO
+            const orgs = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.id).to.be.a.string()
+            expect(org.name).to.be.equal('DHIS2')
+
+            const res = await Organisation.addUserById(org.id, userId, db)
+
+            const orgWithUsers = await Organisation.findOne(org.id, true, db)
+            expect(orgWithUsers).to.include('name')
+            expect(orgWithUsers.name).to.be.equal('DHIS2')
+            expect(orgWithUsers.users).to.be.an.array()
+            const user = orgWithUsers.users.find(
+                u => u.name === 'Erik Arenhill'
+            )
+            expect(user).to.not.be.undefined()
+            expect(user.email).to.be.equal('erik@dhis2.org')
+        })
+
+        it('should throw if user already exists in organisation', async () => {
+            const userId = UserMocks[1].id //Erik, in WHO
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.id).to.be.a.string()
+            expect(org.name).to.be.equal('World Health Organization')
+            await expect(
+                Organisation.addUserById(org.id, userId, db)
+            ).to.reject(Error)
+        })
+
+        it('should work within a transaction', async () => {
+            const userId = UserMocks[2].id //Viktor, in DHIS2
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.id).to.be.a.string()
+            expect(org.name).to.be.equal('World Health Organization')
+
+            const addUserAndGetOrg = async trx => {
+                await Organisation.addUserById(org.id, userId, trx)
+                const orgWithUsers = await Organisation.findOne(
+                    org.id,
+                    true,
+                    trx
+                )
+                return orgWithUsers
+            }
+
+            const orgWithUsers = await db.transaction(addUserAndGetOrg)
+            const newlyAddedUser = orgWithUsers.users.find(
+                u => u.name === 'Viktor Varland'
+            )
+            expect(newlyAddedUser).to.not.be.undefined()
+        })
+
+        it('should rollback within a transaction', async () => {
+            const userId = UserMocks[1].id //Erik, in WHO
+            const appstoreUserId = UserMocks[0].id // Appstore, in DHIS2
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+            const whoOrg = orgs[0]
+            expect(orgs.length).to.be.equal(1)
+
+            expect(whoOrg.id).to.be.a.string()
+            expect(whoOrg.name).to.be.equal('World Health Organization')
+
+            const addUser = async trx => {
+                // appstoreUser to who
+                await Organisation.addUserById(whoOrg.id, appstoreUserId, trx)
+                const orgWithUsers = await Organisation.findOne(
+                    whoOrg.id,
+                    true,
+                    trx
+                )
+                expect(orgWithUsers.users).to.be.an.array()
+                const newUser = orgWithUsers.users.find(
+                    u => u.name === 'Mr Jenkins'
+                )
+                expect(newUser).to.not.be.undefined()
+                // add Erik to WHO, should fail
+                await Organisation.addUserById(whoOrg.id, userId, trx)
+                return true
+            }
+
+            try {
+                const res = await db.transaction(addUser)
+            } catch (e) {
+                expect(e).to.be.an.error()
+                const orgWithUsers = await Organisation.findOne(
+                    whoOrg.id,
+                    true,
+                    db
+                )
+                expect(orgWithUsers.users).to.be.an.array()
+                const newUser = orgWithUsers.users.find(
+                    u => u.name === 'Mr Jenkins'
+                )
+                // should be rollbacked, so user should not have been added
+                expect(newUser).to.be.undefined()
+            }
+        })
+    })
+
+    describe('create', () => {
+        it('should create successfully', async () => {
+            const userId = UserMocks[0].id // appstore
+            const name = 'Unicef'
+            const org = await Organisation.create({ userId, name }, db)
+            expect(org.id).to.be.a.string()
+        })
+
+        it('should fail to create when organisation is not unique', async () => {
+            const userId = UserMocks[0].id // appstore
+            const name = 'DHIS2'
+            const org = await expect(
+                Organisation.create({ userId, name }, db)
+            ).to.reject()
+        })
+
+        it('should work within a transaction', async () => {
+            const userId = UserMocks[0].id // appstore
+            const jenkins = await getUserByEmail('apphub-api@dhis2.org', db)
+            const name = 'Sintef'
+
+            const createAndGetOrg = async trx => {
+                const { id } = await Organisation.create({ userId, name }, trx)
+                expect(id).to.be.a.string()
+                return await Organisation.findOne(id, true, trx)
+            }
+
+            const org = await db.transaction(createAndGetOrg)
+            expect(org.name).to.be.equal(name)
+            expect(org.owner).to.be.equal(jenkins.id)
+        })
+    })
+
+    describe('update', () => {
+        it('should update name successfully', async () => {
+            const orgName = 'World Health Organization'
+            const orgs = await Organisation.find(
+                { filter: { name: orgName } },
+                db
+            )
+            expect(orgs).to.have.length(1)
+            const org = orgs[0]
+            expect(org.name).to.be.equal(orgName)
+
+            await Organisation.update(
+                org.id,
+                {
+                    name: 'WHO',
+                },
+                db
+            )
+
+            const updatedOrg = await Organisation.findOne(org.id, false, db)
+            expect(updatedOrg.name).to.be.equal('WHO')
+            expect(updatedOrg.id).to.be.equal(org.id)
+        })
+
+        it('should set owner successfully', async () => {
+            const user = await getUserByEmail('viktor@dhis2.org', db)
+            const orgs = await Organisation.find(
+                { filter: { name: 'WHO' } },
+                db
+            )
+            expect(orgs).to.have.length(1)
+            const org = orgs[0]
+            const oldOwner = org.owner
+            expect(org.owner).to.not.be.equal(user.id)
+            await Organisation.update(org.id, { owner: user.id }, db)
+
+            const [updatedOrg] = await Organisation.find(
+                { filter: { name: 'WHO' } },
+                db
+            )
+            expect(updatedOrg).to.not.be.undefined()
+            expect(updatedOrg.owner).to.be.equal(user.id)
+
+            //reset to old owner
+            await Organisation.update(org.id, { owner: oldOwner }, db)
+        })
+
+        it('should update name and owner successfully', async () => {
+            const user = UserMocks[0]
+            const org = OrganisationMocks[1]
+
+            expect(org.owner).to.not.be.equal(user.id)
+            await Organisation.update(
+                org.id,
+                { name: 'World Health Organization', owner: user.id },
+                db
+            )
+
+            const updatedOrg = await Organisation.findOne(org.id, false, db)
+
+            expect(updatedOrg).to.be.an.object()
+            expect(updatedOrg.owner).to.be.equal(user.id)
+            expect(updatedOrg.name).to.be.equal('World Health Organization')
+            //reset to old owner
+            await Organisation.update(
+                org.id,
+                { owner: org.created_by_user_id },
+                db
+            )
+        })
+    })
+})


### PR DESCRIPTION
I've been deep down a rabbit hole of trying out multiple approaches to how to deal with database-results etc. My original branch was starting to get quite far behind, with a lot of random commits that does not make sense anymore, so the result is that I brought some of the ideas to this branch, and if we like it I can introduce the other stuff as well (eg. filtering and paging).

This touches on most of the keypoints in the [issue](#139) raised earlier. I will try to tackle the keypoints and explain my thoughts.

### Services
 We didn't want an ORM and that's fine. However I found using the raw database results very cumbersome. "Service" is a very imprecise term, but it's what I came to call this, but they are not classes or injected in any way - they are simple functions exported together. I'm not opposed to splitting up in different files, but having an index-file or the like to group them so you can do `Organisation.find()` is more developer friendly in my opinion. The services are not fundamentally different from the current "data-consept". They are simple functions that fetch data using knex, but also transform this using the models to an internal model. 

 We can also reuse the data-handlers if we want to extract that code out of the services, but as I tried out filters etc. I found that it was better to be able to access the queries directly instead of executing them elsewhere. 

Keypoints:
- Solves transactions annoyances. Every service-function takes in a db-parameter as the last parameter and can thus be given a transaction to compose other service-functions together in a single transactions. See the tests ([1](https://github.com/dhis2/app-store/pull/158/files#diff-56c19ccaec8e083002b4d7770c1dbce6R152)) for examples of this.
   - An annoying part of this is that it can be easy to forget to pass this parameter, crashing the app. Potential solutions: a default-parameter and set it to the knex-instance, register the service as a plugin (and have access to knex from the context) or just keep it as is. 
- Easier to import and use, less verbose naming. The ideas is that we have common function-names per service, ie `find, create, findByUuid, remove, etc`. Where eg. `find` would accept a filter-object that can be used to construct a filtered-query according to passed query-params.

### Models

I really tried to stay away from classes here, but in many ways it would make sense. In the end I decided to use joi-schemas to describe the object and simple transformations. The idea is that we have three "model-shapes". `Internal`, `database` and `external`. Using [`joi.alter()`](https://hapi.dev/family/joi/?v=16.1.7#anyaltertargets) and [`joi.tailor()`](https://hapi.dev/family/joi/?v=16.1.7#anytailortargets), we can use the same base and describe what changes to schema we want per key. We can also expand upon the schemas using `.append()`.

The idea is that the described object is the "internal" model. This should hopefully be pretty similiar to the external-output. Renames on the internal model (without alterations) are from db -> internal, as this was the use case I wanted solve at first.

The idea of `external` is still work in progress, and some endpoints would probably want other schemas and validations per endpoint, but the idea is that they can use this schema as a base, and either expand or restrict based on that shape, and keep common external rules together (ie strip IDs).

When an object is fetched from the database we call `parseDatabaseJson`. This function can be changed to anything, but for simple transformations like renaming, I've opted for a default function that basically just maps the result through the joi schema.

One downside is that we lock in to joi, however it's very powerful and quite easy to get into (atleast the concepts I've used). 

Keypoints: 

- Joi used for transforming and validating data
- Override functions (`parseDatabaseJson`, `formatDatabaseJson`) if we need more special handling (mapping from id to uuid)
### Error handling

As you can see I don't try to manually catch errors. I believe that catching e.g. database-errors and rethrowing them as a custom error like `Failed to get organisation ${error}` is just unncessary code. I might be lazy, but just letting the native errors bubble up is cleaner in my opinion. I've also worked on a solution to map these errors using [db-errors](https://github.com/Vincit/db-errors) to client-friendly errors.

On another note I believe using [`joi.attempt`](https://hapi.dev/family/joi/?v=16.1.7#attemptvalue-schema-message-options) instead of `joi.validate` is the way to go, as we tend to just check for the error and throw that anyways.

TODO:

- [ ] Add route handler for organisation

This explanation is pretty much longer than the code, so I hope that you look through it and respond with some feedback! 