### PR TITLE
feat: errormapper-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,6 +6882,11 @@
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
             "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
+        "db-errors": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz",
+            "integrity": "sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng=="
+        },
         "debug": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "copy-webpack-plugin": "^5.1.1",
         "core-js": "^3.4.8",
         "css-loader": "^0.26.1",
+        "db-errors": "^0.2.3",
         "debug": "^4.1.1",
         "dotenv": "^6.2.0",
         "file-loader": "^3.0.1",
@@ -74,6 +75,7 @@
         "regenerator-runtime": "^0.13.3",
         "rxjs": "6",
         "sass-loader": "^6.0.6",
+        "semver": "^6.3.0",
         "slugify": "^1.3.4",
         "style-loader": "^0.13.1",
         "svg-loader": "^0.0.2",
@@ -81,8 +83,7 @@
         "uuid": "^3.3.2",
         "webpack": "^4.41.2",
         "webpack-dev-server": "^3.8.2",
-        "whatwg-fetch": "^2.0.3",
-        "semver": "^6.3.0"
+        "whatwg-fetch": "^2.0.3"
     },
     "devDependencies": {
         "@babel/register": "^7.6.2",

--- a/src/models/v2/Default.js
+++ b/src/models/v2/Default.js
@@ -1,0 +1,39 @@
+const joi = require('@hapi/joi')
+
+const definition = joi
+    .object()
+    .keys({
+        id: joi.number().alter({ external: s => s.strip()}),
+        uuid: joi.string().guid({ version: 'uuidv4' }),
+        updatedAt: joi
+            .date()
+            .cast('number')
+            .allow(null),
+        createdAt: joi.date().cast('number'),
+    })
+    .rename('updated_at', 'updatedAt', { ignoreUndefined: true })
+    .rename('created_at', 'createdAt', { ignoreUndefined: true })
+    .prefs({
+       stripUnknown: true,
+    })
+
+/**
+ * Creates a default function to parse database result to internal model. Validating
+ * and transforming using the given definition (a joi schema).
+ * @param {Joi.Schema} defintion - The joi schema to use
+ *
+ * @returns {function(dbResult): []} - A function taking the database result (may be an array or object) that validates and transforms
+ * the results according to the joi-schema.
+ * The function throws a ValidationError if mapping fails
+ */
+function createDefaultParseDatabaseJson(schema) {
+    return function(dbResult) {
+        return Array.isArray(dbResult) ? dbResult.map(v => joi.attempt(v, schema)) : joi.attempt(dbResult, schema)
+    }
+}
+
+module.exports = {
+    def: definition,
+    definition,
+    createDefaultParseDatabaseJson,
+}

--- a/src/models/v2/Default.js
+++ b/src/models/v2/Default.js
@@ -18,15 +18,14 @@ const definition = joi
     })
 
 /**
- * Creates a default function to parse database result to internal model. Validating
- * and transforming using the given definition (a joi schema).
+ * Creates a default function to validating
+ * and transform results the given definition (a joi schema).
  * @param {Joi.Schema} defintion - The joi schema to use
  *
- * @returns {function(dbResult): []} - A function taking the database result (may be an array or object) that validates and transforms
- * the results according to the joi-schema.
+ * @returns {function(dbResult): []} - A function taking some data (may be an array or object) to be validated by the schema.
  * The function throws a ValidationError if mapping fails
  */
-function createDefaultParseDatabaseJson(schema) {
+function createDefaultValidator(schema) {
     return function(dbResult) {
         return Array.isArray(dbResult) ? dbResult.map(v => joi.attempt(v, schema)) : joi.attempt(dbResult, schema)
     }
@@ -35,5 +34,5 @@ function createDefaultParseDatabaseJson(schema) {
 module.exports = {
     def: definition,
     definition,
-    createDefaultParseDatabaseJson,
+    createDefaultValidator,
 }

--- a/src/models/v2/Default.js
+++ b/src/models/v2/Default.js
@@ -3,8 +3,7 @@ const joi = require('@hapi/joi')
 const definition = joi
     .object()
     .keys({
-        id: joi.number().alter({ external: s => s.strip()}),
-        uuid: joi.string().guid({ version: 'uuidv4' }),
+        id: joi.string().guid({ version: 'uuidv4' }),
         updatedAt: joi
             .date()
             .cast('number')
@@ -14,7 +13,7 @@ const definition = joi
     .rename('updated_at', 'updatedAt', { ignoreUndefined: true })
     .rename('created_at', 'createdAt', { ignoreUndefined: true })
     .prefs({
-       stripUnknown: true,
+        stripUnknown: true,
     })
 
 /**
@@ -27,7 +26,9 @@ const definition = joi
  */
 function createDefaultValidator(schema) {
     return function(dbResult) {
-        return Array.isArray(dbResult) ? dbResult.map(v => joi.attempt(v, schema)) : joi.attempt(dbResult, schema)
+        return Array.isArray(dbResult)
+            ? dbResult.map(v => joi.attempt(v, schema))
+            : joi.attempt(dbResult, schema)
     }
 }
 

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -14,6 +14,7 @@ const definition = defaultDefinition
         createdByUserId: joi.number().alter({
             external: s => s.strip(),
         }),
+        users: joi.array().items(User.definition),
     })
     .alter({
         db: s =>

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -47,12 +47,15 @@ const filter = joi
 
 const dbDefinition = definition.tailor('db')
 
+const externalDefintion = definition.tailor('external')
+
 const parseDatabaseJson = createDefaultParseDatabaseJson(definition)
 
 module.exports = {
     def: definition,
     definition,
     dbDefinition,
+    externalDefintion,
     defWithUsers,
     parseDatabaseJson,
     filter,

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -2,14 +2,14 @@ const joi = require('@hapi/joi')
 const User = require('./User')
 const {
     definition: defaultDefinition,
-    createDefaultParseDatabaseJson,
+    createDefaultValidator,
 } = require('./Default')
 
 const definition = defaultDefinition
     .append({
         name: joi.string(),
         slug: joi.string(),
-        // createdByUser: joi.string(),
+        // createdByUser: joi.string(),   TODO: should we rename 'createdByUserUuid' to this and use that for internal and external models?
         createdByUserUuid: joi.string(),
         createdByUserId: joi.number().alter({
             external: s => s.strip(),
@@ -25,8 +25,6 @@ const definition = defaultDefinition
         ignoreUndefined: true,
     })
 
-const renamer = (to, from, opts) => s => s.rename(to, from, opts)
-
 const defWithUsers = definition.append({
     users: joi
         .array()
@@ -34,22 +32,13 @@ const defWithUsers = definition.append({
         .required(),
 })
 
-const filter = joi
-    .object({
-        uuid: joi.string().guid(),
-        name: joi.string(),
-        slug: joi.string(),
-        userUuid: joi.string().guid(),
-    })
-    .prefs({
-        stripUnknown: true,
-    })
-
 const dbDefinition = definition.tailor('db')
 
 const externalDefintion = definition.tailor('external')
 
-const parseDatabaseJson = createDefaultParseDatabaseJson(definition)
+const parseDatabaseJson = createDefaultValidator(definition)
+
+const formatDatabaseJson = createDefaultValidator(dbDefinition);
 
 module.exports = {
     def: definition,
@@ -58,5 +47,5 @@ module.exports = {
     externalDefintion,
     defWithUsers,
     parseDatabaseJson,
-    filter,
+    formatDatabaseJson
 }

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -1,0 +1,59 @@
+const joi = require('@hapi/joi')
+const User = require('./User')
+const {
+    definition: defaultDefinition,
+    createDefaultParseDatabaseJson,
+} = require('./Default')
+
+const definition = defaultDefinition
+    .append({
+        name: joi.string(),
+        slug: joi.string(),
+        // createdByUser: joi.string(),
+        createdByUserUuid: joi.string(),
+        createdByUserId: joi.number().alter({
+            external: s => s.strip(),
+        }),
+    })
+    .alter({
+        db: s =>
+            s
+                .append({ created_by_user_id: joi.number() })
+                .rename('createdByUserId', 'created_by_user_id'),
+    })
+    .rename('created_by_user_uuid', 'createdByUserUuid', {
+        ignoreUndefined: true,
+    })
+
+const renamer = (to, from, opts) => s => s.rename(to, from, opts)
+
+const defWithUsers = definition.append({
+    users: joi
+        .array()
+        .items(User.definition)
+        .required(),
+})
+
+const filter = joi
+    .object({
+        uuid: joi.string().guid(),
+        name: joi.string(),
+        slug: joi.string(),
+        userUuid: joi.string().guid(),
+    })
+    .prefs({
+        stripUnknown: true,
+    })
+
+const dbDefinition = definition.tailor('db')
+
+const parseDatabaseJson = createDefaultParseDatabaseJson(definition)
+
+module.exports = {
+    def: definition,
+    definition,
+    dbDefinition,
+    defWithUsers,
+    parseDatabaseJson,
+    filter,
+}

--- a/src/models/v2/Organisation.js
+++ b/src/models/v2/Organisation.js
@@ -9,20 +9,20 @@ const definition = defaultDefinition
     .append({
         name: joi.string(),
         slug: joi.string(),
-        // createdByUser: joi.string(),   TODO: should we rename 'createdByUserUuid' to this and use that for internal and external models?
-        createdByUserUuid: joi.string(),
-        createdByUserId: joi.number().alter({
-            external: s => s.strip(),
-        }),
+        createdByUser: joi.string().guid({ version: 'uuidv4' }),
         users: joi.array().items(User.definition),
     })
     .alter({
         db: s =>
             s
-                .append({ created_by_user_id: joi.number() })
-                .rename('createdByUserId', 'created_by_user_id'),
+                .append({
+                    created_by_user_id: joi
+                        .string()
+                        .guid({ version: 'uuidv4' }),
+                })
+                .rename('createdByUser', 'created_by_user_id'),
     })
-    .rename('created_by_user_uuid', 'createdByUserUuid', {
+    .rename('created_by_user_id', 'createdByUser', {
         ignoreUndefined: true,
     })
 
@@ -39,7 +39,7 @@ const externalDefintion = definition.tailor('external')
 
 const parseDatabaseJson = createDefaultValidator(definition)
 
-const formatDatabaseJson = createDefaultValidator(dbDefinition);
+const formatDatabaseJson = createDefaultValidator(dbDefinition)
 
 module.exports = {
     def: definition,
@@ -48,5 +48,5 @@ module.exports = {
     externalDefintion,
     defWithUsers,
     parseDatabaseJson,
-    formatDatabaseJson
+    formatDatabaseJson,
 }

--- a/src/models/v2/User.js
+++ b/src/models/v2/User.js
@@ -1,0 +1,18 @@
+const joi = require('@hapi/joi')
+const {
+    definition: defaultDefinition,
+    createDefaultParseDatabaseJson,
+} = require('./Default')
+
+const definition = defaultDefinition.append({
+    name: joi.string(),
+    email: joi.string(),
+})
+
+const parseDatabaseJson = createDefaultParseDatabaseJson(definition)
+
+module.exports = {
+    def: definition,
+    definition,
+    parseDatabaseJson,
+}

--- a/src/models/v2/User.js
+++ b/src/models/v2/User.js
@@ -1,7 +1,7 @@
 const joi = require('@hapi/joi')
 const {
     definition: defaultDefinition,
-    createDefaultParseDatabaseJson,
+    createDefaultValidator,
 } = require('./Default')
 
 const definition = defaultDefinition.append({
@@ -9,7 +9,7 @@ const definition = defaultDefinition.append({
     email: joi.string(),
 })
 
-const parseDatabaseJson = createDefaultParseDatabaseJson(definition)
+const parseDatabaseJson = createDefaultValidator(definition)
 
 module.exports = {
     def: definition,

--- a/src/plugins/errorMapper.js
+++ b/src/plugins/errorMapper.js
@@ -1,0 +1,59 @@
+const { NotFoundError } = require('../utils/errors')
+const Boom = require('@hapi/boom')
+const {
+    UniqueViolationError,
+    ForeignKeyViolationError,
+    NotNullViolationError,
+    CheckViolationError,
+    DBError,
+    DataError,
+    ConstraintViolationError,
+} = require('db-errors')
+
+const dbErrorMap = {
+    badRequest: [
+        CheckViolationError,
+        ConstraintViolationError,
+        DataError,
+        ForeignKeyViolationError,
+        NotNullViolationError,
+    ],
+    conflict: [UniqueViolationError],
+    notFound: [NotFoundError],
+    internal: [DBError],
+}
+
+const onPreResponseHandler = function(request, h) {
+    const { response: error } = request
+    // not error or joi-error, ignore
+    if (!error.isBoom || error.isJoi) {
+        return h.continue
+    }
+    throw mapError(error, this.options)
+}
+
+const mapError = (error, options) => {
+    for (const key in dbErrorMap) {
+        const httpError = dbErrorMap[key].find(e => error instanceof e)
+        if (httpError) {
+            return Boom[key](options.preserveMessage ? error.message : null)
+        }
+    }
+    return error
+}
+
+const defaultOptions = {
+    preserveMessage: false,
+}
+
+const errorPlugin = {
+    name: 'ErrorPlugin',
+    register: async (server, options = defaultOptions) => {
+        server.bind({
+            options,
+        })
+        server.ext('onPreResponse', onPreResponseHandler)
+    },
+}
+
+module.exports = errorPlugin

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -1,3 +1,3 @@
 const { flatten } = require('../../utils')
 
-module.exports = [require('./apps.js'), require('./channels.js')]
+module.exports = [require('./apps.js'), require('./channels.js'), require('./organisations')]

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -124,6 +124,7 @@ module.exports = [
                     true,
                     trx
                 )
+
                 const isMember =
                     org.users.findIndex(u => u.id === userUuid) > -1
                 const canAdd = org.createdByUserUuid === userUuid || isMember

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -32,9 +32,7 @@ module.exports = [
             auth: 'token',
             validate: {
                 params: Joi.object({
-                    orgUuid: Joi.string()
-                        .guid()
-                        .required(),
+                    orgUuid: OrgModel.definition.extract('uuid').required(),
                 }),
             },
             tags: ['api', 'v2'],
@@ -74,10 +72,7 @@ module.exports = [
                 db
             )
             return h
-                .response({
-                    ...organisation,
-                    test: 'asf',
-                })
+                .response(organisation)
                 .created(`/v2/organisations/${organisation.uuid}`)
         },
     },
@@ -107,7 +102,7 @@ module.exports = [
         },
         handler: async (request, h) => {
             const { db } = h.context
-            const { id: userId } = getCurrentUserFromRequest(request, db)
+            const { uuid: userUuid } = await getCurrentUserFromRequest(request, db)
             const userEmailToAdd = request.payload.email
 
             const addUserToOrganisation = async trx => {
@@ -116,11 +111,11 @@ module.exports = [
                     true,
                     trx
                 )
-                const isMember = org.users.findIndex(u => u.id === userId) > -1
-                const canAdd = org.createdByUserId === userId || isMember
+                const isMember = org.users.findIndex(u => u.id === userUuid) > -1
+                const canAdd = org.createdByUserUuid === userUuid || isMember
 
-                if (!canAdd) {
-                    throw Boom.unauthorized(
+                if (!canAdd) {qq
+                    throw Boom.forbidden(
                         'You do not have permission to add users'
                     )
                 }

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -15,13 +15,17 @@ module.exports = [
         path: '/v2/organisations',
         config: {
             tags: ['api', 'v2'],
+            response: {
+                schema: Joi.array().items(OrgModel.externalDefintion),
+                modify: true
+            },
         },
         handler: async (request, h) => {
             const { db } = h.context
 
             //get all orgs, no filtering
+            //TODO: add filtering
             const orgs = await Organisation.find({}, h.context.db)
-
             return orgs
         },
     },
@@ -37,12 +41,13 @@ module.exports = [
             },
             tags: ['api', 'v2'],
             response: {
-                //   schema: OrgModel.externalDefintion,
+                schema: OrgModel.externalDefintion,
+                modify: true
             },
         },
-        handler: (request, h) => {
+        handler: async (request, h) => {
             const { db } = h.context
-            const organisation = Organisation.findByUuid(orgUuid, true, db)
+            const organisation = await Organisation.findByUuid(orgUuid, true, db)
             return organisation
         },
     },
@@ -78,7 +83,7 @@ module.exports = [
     },
     {
         method: 'POST',
-        path: '/v2/organisations/{orgUuid}/add',
+        path: '/v2/organisations/{orgUuid}/addUser',
         config: {
             auth: 'token',
             tags: ['api', 'v2'],
@@ -114,7 +119,7 @@ module.exports = [
                 const isMember = org.users.findIndex(u => u.id === userUuid) > -1
                 const canAdd = org.createdByUserUuid === userUuid || isMember
 
-                if (!canAdd) {qq
+                if (!canAdd) {
                     throw Boom.forbidden(
                         'You do not have permission to add users'
                     )

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -1,0 +1,149 @@
+const Boom = require('@hapi/boom')
+const Joi = require('@hapi/joi')
+const {
+    canCreateApp,
+    getCurrentAuthStrategy,
+    getCurrentUserFromRequest,
+} = require('../../security')
+const getUserByEmail = require('../../data/getUserByEmail')
+const { Organisation } = require('../../services')
+const OrgModel = require('../../models/v2/Organisation')
+
+module.exports = [
+    {
+        method: 'GET',
+        path: '/v2/organisations',
+        config: {
+            tags: ['api', 'v2'],
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+
+            //get all orgs, no filtering
+            const orgs = await Organisation.find({}, h.context.db)
+
+            return orgs
+        },
+    },
+    {
+        method: 'GET',
+        path: '/v2/organisations/{orgUuid}',
+        config: {
+            auth: 'token',
+            validate: {
+                params: Joi.object({
+                    orgUuid: Joi.string()
+                        .guid()
+                        .required(),
+                }),
+            },
+            tags: ['api', 'v2'],
+            response: {
+                //   schema: OrgModel.externalDefintion,
+            },
+        },
+        handler: (request, h) => {
+            const { db } = h.context
+            const organisation = Organisation.findByUuid(orgUuid, true, db)
+            return organisation
+        },
+    },
+    {
+        method: 'POST',
+        path: '/v2/organisations',
+        config: {
+            auth: 'token',
+            validate: {
+                payload: Joi.object({
+                    name: OrgModel.definition.extract('name').required(),
+                }),
+            },
+            tags: ['api', 'v2'],
+            response: {
+                schema: OrgModel.externalDefintion,
+                modify: true,
+            },
+        },
+
+        handler: async (request, h) => {
+            const { db } = h.context
+
+            const { id: userId } = await getCurrentUserFromRequest(request, db)
+            const organisation = await Organisation.create(
+                { userId, name: request.payload.name },
+                db
+            )
+            return h
+                .response({
+                    ...organisation,
+                    test: 'asf',
+                })
+                .created(`/v2/organisations/${organisation.uuid}`)
+        },
+    },
+    {
+        method: 'POST',
+        path: '/v2/organisations/{orgUuid}/add',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+            validate: {
+                payload: Joi.object({
+                    email: Joi.string()
+                        .email()
+                        .required(),
+                }),
+                params: Joi.object({
+                    orgUuid: Joi.string()
+                        .guid()
+                        .required(),
+                }),
+            },
+            // response: {
+            //     status: {
+            //         //TODO: add response statuses
+            //     },
+            // },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id: userId } = getCurrentUserFromRequest(request, db)
+            const userEmailToAdd = request.payload.email
+
+            const addUserToOrganisation = async trx => {
+                const org = await Organisation.findByUuid(
+                    request.params.orgUuid,
+                    true,
+                    trx
+                )
+                const isMember = org.users.findIndex(u => u.id === userId) > -1
+                const canAdd = org.createdByUserId === userId || isMember
+
+                if (!canAdd) {
+                    throw Boom.unauthorized(
+                        'You do not have permission to add users'
+                    )
+                }
+
+                const userToAdd = await getUserByEmail(
+                    request.payload.email,
+                    trx
+                )
+                if (userToAdd && userToAdd.id) {
+                    await Organisation.addUserById(org.uuid, userToAdd.id, trx)
+                    return userToAdd
+                } else {
+                    throw Boom.conflict(
+                        `User with email '${userEmailToAdd} not found.`
+                    )
+                }
+            }
+
+            const transaction = await db.transaction(addUserToOrganisation)
+
+            return {
+                statusCode: 200,
+            }
+        },
+    },
+]

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -47,6 +47,7 @@ module.exports = [
         },
         handler: async (request, h) => {
             const { db } = h.context
+            const {orgUuid} = request.params;
             const organisation = await Organisation.findByUuid(orgUuid, true, db)
             return organisation
         },

--- a/src/routes/v2/organisations.js
+++ b/src/routes/v2/organisations.js
@@ -17,7 +17,7 @@ module.exports = [
             tags: ['api', 'v2'],
             response: {
                 schema: Joi.array().items(OrgModel.externalDefintion),
-                modify: true
+                modify: true,
             },
         },
         handler: async (request, h) => {
@@ -42,13 +42,17 @@ module.exports = [
             tags: ['api', 'v2'],
             response: {
                 schema: OrgModel.externalDefintion,
-                modify: true
+                modify: true,
             },
         },
         handler: async (request, h) => {
             const { db } = h.context
-            const {orgUuid} = request.params;
-            const organisation = await Organisation.findByUuid(orgUuid, true, db)
+            const { orgUuid } = request.params
+            const organisation = await Organisation.findByUuid(
+                orgUuid,
+                true,
+                db
+            )
             return organisation
         },
     },
@@ -84,7 +88,7 @@ module.exports = [
     },
     {
         method: 'POST',
-        path: '/v2/organisations/{orgUuid}/addUser',
+        path: '/v2/organisations/{orgUuid}/user',
         config: {
             auth: 'token',
             tags: ['api', 'v2'],
@@ -108,7 +112,10 @@ module.exports = [
         },
         handler: async (request, h) => {
             const { db } = h.context
-            const { uuid: userUuid } = await getCurrentUserFromRequest(request, db)
+            const { uuid: userUuid } = await getCurrentUserFromRequest(
+                request,
+                db
+            )
             const userEmailToAdd = request.payload.email
 
             const addUserToOrganisation = async trx => {
@@ -117,7 +124,8 @@ module.exports = [
                     true,
                     trx
                 )
-                const isMember = org.users.findIndex(u => u.id === userUuid) > -1
+                const isMember =
+                    org.users.findIndex(u => u.id === userUuid) > -1
                 const canAdd = org.createdByUserUuid === userUuid || isMember
 
                 if (!canAdd) {

--- a/src/security/index.js
+++ b/src/security/index.js
@@ -70,6 +70,7 @@ const getCurrentUserFromRequest = async request => {
         try {
             const user = {
                 id: request.auth.credentials.userId,
+                uuid: request.auth.credentials.uuid,
             }
             resolve(user)
         } catch (err) {

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    Organisation: require('./organisation'),
+}

--- a/src/services/organisation/index.js
+++ b/src/services/organisation/index.js
@@ -31,7 +31,7 @@ async function create({ userId, name }, db) {
         slug,
         uuid: uuid(),
     }
-    const dbData = joi.attempt(obj, Organisation.dbDefinition)
+    const dbData = Organisation.formatDatabaseJson(obj)
     const [organisation] = await db('organisation')
         .insert(dbData)
         .returning(['id', 'uuid'])

--- a/src/services/organisation/index.js
+++ b/src/services/organisation/index.js
@@ -1,0 +1,145 @@
+const joi = require('@hapi/joi')
+const slugify = require('slugify')
+const uuid = require('uuid/v4')
+const { applyFiltersToQuery } = require('../../utils/databaseUtils')
+const { NotFoundError } = require('../../utils/errors')
+const Boom = require('@hapi/boom')
+const User = require('../../models/v2/User')
+const Organisation = require('../../models/v2/Organisation')
+
+const getOrganisationQuery = db =>
+    db('organisation')
+        .select(
+            'organisation.id',
+            'organisation.uuid',
+            'organisation.name',
+            'organisation.slug',
+            db.ref('u.uuid').as('created_by_user_uuid'),
+            db.ref('u.id').as('created_by_user_id')
+        )
+        .innerJoin(
+            db.ref('users').as('u'),
+            'organisation.created_by_user_id',
+            'u.id'
+        )
+
+async function create({ userId, name }, db) {
+    const slug = await ensureUniqueSlug(slugify(name, { lower: true }), db)
+    const obj = {
+        createdByUserId: userId,
+        name,
+        slug,
+        uuid: uuid(),
+    }
+    const dbData = joi.attempt(obj, Organisation.dbDefinition)
+    const [organisation] = await db('organisation')
+        .insert(dbData)
+        .returning(['id', 'uuid'])
+
+    return Organisation.parseDatabaseJson(organisation)
+}
+
+async function ensureUniqueSlug(originalSlug, db) {
+    let slug = originalSlug
+    let slugUniqueness = 2
+    let foundUniqueSlug = false
+    while (!foundUniqueSlug) {
+        const [{ count }] = await db('organisation')
+            .count('id')
+            .where('slug', slug)
+        if (count > 0) {
+            slug = `${originalSlug}-${slugUniqueness}`
+            slugUniqueness++
+        } else {
+            foundUniqueSlug = true
+        }
+    }
+
+    return slug
+}
+
+async function find({ filter, paging }, db) {
+    const query = getOrganisationQuery(db)
+
+    if (filter) {
+        // special filter for gettings orgs for a particular user
+        if (filter.userUuid) {
+            const userOrganisations = db('user_organisation')
+                .select('organisation_id')
+                .innerJoin('users', 'user_organisation.user_id', 'users.id')
+                .where('users.uuid', filter.userUuid)
+
+            query.whereIn('organisation.id', userOrganisations)
+            delete filter.userUuid
+        }
+        applyFiltersToQuery(filter, query, { tableName: 'organisation' })
+    }
+    const res = await query
+    const parsed = Organisation.parseDatabaseJson(res)
+
+    return parsed
+}
+
+async function findByUuid(uuid, includeUsers = false, db) {
+    const organisation = await getOrganisationQuery(db)
+        .first()
+        .where('organisation.uuid', uuid)
+    if (!organisation) {
+        throw new NotFoundError(`Organisation with uuid ${uuid} not found.`)
+    }
+
+    const internalOrg = Organisation.parseDatabaseJson(organisation)
+
+    if (includeUsers) {
+        const users = await db('users')
+            .select('users.uuid', 'users.email', 'users.name')
+            .innerJoin(
+                'user_organisation',
+                'users.id',
+                'user_organisation.user_id'
+            )
+            .where('user_organisation.organisation_id', organisation.id)
+        internalOrg.users = User.parseDatabaseJson(users)
+    }
+
+    return internalOrg
+}
+
+async function addUserById(uuid, userId, db) {
+    const org = await findByUuid(uuid, false, db)
+
+    const query = await db('user_organisation').insert({
+        user_id: userId,
+        organisation_id: org.id,
+    })
+
+    return query
+}
+
+async function remove(uuid, db) {
+    await db('organisation')
+        .where({ uuid })
+        .delete()
+}
+
+async function setCreatedByUserId(uuid, userId, db) {
+    const dbData = joi.attempt(
+        {
+            createdByUserId: userId,
+        },
+        Organisation.dbDefinition
+    )
+
+    await db('organisation')
+        .update(dbData)
+        .where({ uuid })
+}
+
+module.exports = {
+    find,
+    findByUuid,
+    addUserById,
+    create,
+    remove,
+    setCreatedByUserId,
+}

--- a/src/services/organisation/index.js
+++ b/src/services/organisation/index.js
@@ -3,7 +3,6 @@ const slugify = require('slugify')
 const uuid = require('uuid/v4')
 const { applyFiltersToQuery } = require('../../utils/databaseUtils')
 const { NotFoundError } = require('../../utils/errors')
-const Boom = require('@hapi/boom')
 const User = require('../../models/v2/User')
 const Organisation = require('../../models/v2/Organisation')
 
@@ -23,7 +22,7 @@ const getOrganisationQuery = db =>
             'u.id'
         )
 
-async function create({ userId, name }, db) {
+const create = async ({ userId, name }, db) => {
     const slug = await ensureUniqueSlug(slugify(name, { lower: true }), db)
     const obj = {
         createdByUserId: userId,
@@ -39,7 +38,7 @@ async function create({ userId, name }, db) {
     return Organisation.parseDatabaseJson(organisation)
 }
 
-async function ensureUniqueSlug(originalSlug, db) {
+const ensureUniqueSlug = async (originalSlug, db) => {
     let slug = originalSlug
     let slugUniqueness = 2
     let foundUniqueSlug = false
@@ -58,7 +57,7 @@ async function ensureUniqueSlug(originalSlug, db) {
     return slug
 }
 
-async function find({ filter, paging }, db) {
+const find = async ({ filter, paging }, db) => {
     const query = getOrganisationQuery(db)
 
     if (filter) {
@@ -80,7 +79,7 @@ async function find({ filter, paging }, db) {
     return parsed
 }
 
-async function findByUuid(uuid, includeUsers = false, db) {
+const findByUuid = async (uuid, includeUsers = false, db) => {
     const organisation = await getOrganisationQuery(db)
         .first()
         .where('organisation.uuid', uuid)
@@ -105,7 +104,7 @@ async function findByUuid(uuid, includeUsers = false, db) {
     return internalOrg
 }
 
-async function addUserById(uuid, userId, db) {
+const addUserById = async (uuid, userId, db) => {
     const org = await findByUuid(uuid, false, db)
 
     const query = await db('user_organisation').insert({
@@ -116,13 +115,13 @@ async function addUserById(uuid, userId, db) {
     return query
 }
 
-async function remove(uuid, db) {
+const remove = async (uuid, db) => {
     await db('organisation')
         .where({ uuid })
         .delete()
 }
 
-async function setCreatedByUserId(uuid, userId, db) {
+const setCreatedByUserId = async (uuid, userId, db) => {
     const dbData = joi.attempt(
         {
             createdByUserId: userId,

--- a/src/utils/databaseUtils.js
+++ b/src/utils/databaseUtils.js
@@ -1,0 +1,18 @@
+
+function applyFiltersToQuery(filters, query, { tableName, columnMap }) {
+    for (k in filters) {
+        const colName = columnMap ? columnMap[k] : k
+        if (colName) {
+            query.where(
+                tableName ? `${tableName}.${colName}` : colName,
+                '=',
+                filters[k]
+            )
+        }
+    }
+    return
+}
+
+module.exports = {
+    applyFiltersToQuery
+}

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,10 @@
+class NotFoundError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'NotFoundError';
+    }   
+}
+
+module.exports = {
+    NotFoundError
+}

--- a/test/plugins/errorMapper.js
+++ b/test/plugins/errorMapper.js
@@ -1,0 +1,52 @@
+const Lab = require('@hapi/lab')
+const { it, describe, before } = (exports.lab = Lab.script())
+const { expect, fail } = require('@hapi/code')
+const { flatten } = require('../../src/utils')
+const {
+    UniqueViolationError,
+    ForeignKeyViolationError,
+    NotNullViolationError,
+    CheckViolationError,
+    DBError,
+    DataError,
+    ConstraintViolationError,
+} = require('db-errors')
+const { NotFoundError } = require('../../src/utils/errors')
+const ErrorPlugin = require('../../src/plugins/errorMapper')
+
+const Hapi = require('@hapi/hapi')
+
+describe('ErrorPlugin', () => {
+    let server
+    before(async () => {
+        server = Hapi.server({ port: 3001 })
+
+        await server.register({ plugin: ErrorPlugin })
+
+        server.route({
+            method: 'GET',
+            path: '/null',
+            options: {
+                response: {
+                    failAction: (r, h, err) => {
+                        throw err
+                    },
+                },
+            },
+            handler: () => {
+                throw new NotFoundError('Item was not found!')
+            },
+        })
+    })
+
+    it('should return 404: not found ', async () => {
+        const request = {
+            method: 'GET',
+            url: '/null',
+        }
+        const res = await server.inject(request)
+
+        expect(res.result.statusCode).to.be.equal(404)
+        expect(res.result.message).to.be.equal('Not found')
+    })
+})

--- a/test/plugins/errorMapper.js
+++ b/test/plugins/errorMapper.js
@@ -12,41 +12,223 @@ const {
     ConstraintViolationError,
 } = require('db-errors')
 const { NotFoundError } = require('../../src/utils/errors')
-const ErrorPlugin = require('../../src/plugins/errorMapper')
-
+const ErrorMapperPlugin = require('../../src/plugins/errorMapper')
+const Joi = require('@hapi/joi')
 const Hapi = require('@hapi/hapi')
 
-describe('ErrorPlugin', () => {
+describe('ErrorMapperPlugin', () => {
     let server
-    before(async () => {
-        server = Hapi.server({ port: 3001 })
 
-        await server.register({ plugin: ErrorPlugin })
-
+    const registerRoutes = server => {
         server.route({
             method: 'GET',
             path: '/null',
-            options: {
-                response: {
-                    failAction: (r, h, err) => {
-                        throw err
-                    },
-                },
-            },
             handler: () => {
                 throw new NotFoundError('Item was not found!')
             },
         })
+
+        server.route({
+            method: 'POST',
+            path: '/constraint',
+            handler: () => {
+                throw new ConstraintViolationError({
+                    nativeError: new Error('Constraint violation!'),
+                })
+            },
+        })
+
+        server.route({
+            method: 'POST',
+            path: '/notNull',
+            handler: () => {
+                throw new NotNullViolationError({
+                    nativeError: 'Cannot be null!',
+                })
+            },
+        })
+
+        server.route({
+            method: 'POST',
+            path: '/unique',
+            handler: () => {
+                throw new UniqueViolationError({
+                    nativeError: new Error('Item already exists!'),
+                })
+            },
+        })
+
+        server.route({
+            method: 'GET',
+            path: '/pass',
+            handler: () => {
+                return 'Success!'
+            },
+        })
+
+        server.route({
+            method: 'GET',
+            path: '/internal',
+            handler: () => {
+                throw new Error('An internal error')
+            },
+        })
+
+        server.route({
+            method: 'POST',
+            path: '/validationInHandler',
+            handler: () => {
+                return Joi.attempt(
+                    {
+                        a: 5,
+                    },
+                    Joi.string()
+                )
+            },
+        })
+        server.route({
+            method: 'POST',
+            path: '/validation',
+            config: {
+                validate: {
+                    payload: Joi.object(),
+                },
+            },
+            handler: () => {
+                return 'Success!'
+            },
+        })
+    }
+    describe('Default: preserveMessage=false', () => {
+        before(async () => {
+            server = Hapi.server({ port: 3001 })
+
+            await server.register({ plugin: ErrorMapperPlugin })
+
+            registerRoutes(server)
+        })
+
+        it('should ignore non-error', async () => {
+            const res = await server.inject({
+                method: 'GET',
+                url: '/pass',
+            })
+            expect(res.statusCode).to.be.equal(200)
+            expect(res.result).to.be.equal('Success!')
+        })
+        it('should ignore joi validation-errors', async () => {
+            const res = await server.inject({
+                method: 'POST',
+                url: '/validation',
+            })
+            expect(res.statusCode).to.be.equal(400)
+        })
+
+        it('joi validation-errors should be ignored in handler, so they should return 500', async () => {
+            const res = await server.inject({
+                method: 'POST',
+                url: '/validationInHandler',
+            })
+            expect(res.statusCode).to.be.equal(500)
+        })
+        it('should ignore and rethrow internal errors', async () => {
+            const res = await server.inject({
+                method: 'GET',
+                url: '/internal',
+            })
+
+            expect(res.statusCode).to.be.equal(500)
+            expect(res.result.message).to.be.equal(
+                'An internal server error occurred'
+            )
+        })
+        it('should return 404: not found when NotFoundError is thrown', async () => {
+            const request = {
+                method: 'GET',
+                url: '/null',
+            }
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.be.equal(404)
+            expect(res.result.message).to.be.equal('Not Found')
+        })
+
+        it('should return 400: bad request when ConstraintViolationError is thrown', async () => {
+            const request = {
+                method: 'POST',
+                url: '/constraint',
+            }
+            const res = await server.inject(request)
+            expect(res.statusCode).to.be.equal(400)
+            expect(res.result.message).to.be.equal('Bad Request')
+        })
     })
 
-    it('should return 404: not found ', async () => {
-        const request = {
-            method: 'GET',
-            url: '/null',
-        }
-        const res = await server.inject(request)
+    describe('preserveMessage=true', () => {
+        before(async () => {
+            server = Hapi.server({ port: 3001 })
 
-        expect(res.result.statusCode).to.be.equal(404)
-        expect(res.result.message).to.be.equal('Not found')
+            await server.register({
+                plugin: ErrorMapperPlugin,
+                options: {
+                    preserveMessage: true,
+                },
+            })
+            registerRoutes(server)
+        })
+        it('should ignore non-error', async () => {
+            const res = await server.inject({
+                method: 'GET',
+                url: '/pass',
+            })
+
+            expect(res.statusCode).to.be.equal(200)
+            expect(res.result).to.be.equal('Success!')
+        })
+
+        it('should ignore and rethrow internal errors', async () => {
+            const res = await server.inject({
+                method: 'GET',
+                url: '/internal',
+            })
+
+            expect(res.statusCode).to.be.equal(500)
+            expect(res.result.message).to.be.equal(
+                'An internal server error occurred'
+            )
+        })
+
+        it('should return 404 with preserved message when NotFoundError is thrown', async () => {
+            const request = {
+                method: 'GET',
+                url: '/null',
+            }
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.be.equal(404)
+            expect(res.result.message).to.be.equal('Item was not found!')
+        })
+
+        it('should return 400: bad request with preserved message when ConstraintViolationError is thrown', async () => {
+            const request = {
+                method: 'POST',
+                url: '/constraint',
+            }
+
+            const res = await server.inject(request)
+            expect(res.statusCode).to.be.equal(400)
+            expect(res.result.message).to.be.equal('Constraint violation!')
+        })
+
+        it('should return 409: conflict with preserved message when UniqueViolationError is thrown', async () => {
+            const request = {
+                method: 'POST',
+                url: '/unique',
+            }
+
+            const res = await server.inject(request)
+            expect(res.statusCode).to.be.equal(409)
+            expect(res.result.message).to.be.equal('Item already exists!')
+        })
     })
 })

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -39,13 +39,7 @@ describe('v2/organisations', () => {
 
             const orgs = JSON.parse(res.payload)
             expect(orgs).to.be.an.array()
-            expect(orgs[0]).to.include([
-                'uuid',
-                'name',
-                'slug',
-                'createdByUserUuid',
-            ])
-            expect(orgs[0]).to.not.include(['id', 'createdByUserId'])
+            expect(orgs[0]).to.include(['id', 'name', 'slug', 'createdByUser'])
         })
     })
 
@@ -62,8 +56,8 @@ describe('v2/organisations', () => {
             const res = await server.inject(opts)
             expect(res.statusCode).to.equal(201)
             const payload = JSON.parse(res.payload)
-            expect(payload).to.include(['uuid'])
-            expect(payload.id).to.be.undefined()
+            expect(payload).to.include(['id'])
+            expect(payload.id).to.be.string()
         })
 
         it('should fail if no payload', async () => {
@@ -86,13 +80,13 @@ describe('v2/organisations', () => {
             )
 
             expect(dhis2Org).to.not.be.undefined()
-            expect(dhis2Org.uuid).to.be.a.string()
+            expect(dhis2Org.id).to.be.a.string()
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/user`,
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
                 payload: {
-                    email: 'appstore-api@dhis2.org',
+                    email: 'apphub-api@dhis2.org',
                 },
             }
             const res = await server.inject(opts)
@@ -107,11 +101,11 @@ describe('v2/organisations', () => {
             )
 
             expect(dhis2Org).to.not.be.undefined()
-            expect(dhis2Org.uuid).to.be.a.string()
+            expect(dhis2Org.id).to.be.a.string()
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/user`,
+                url: `/api/v2/organisations/${dhis2Org.id}/user`,
                 payload: {
                     email: 'example-fail@dhis2.org',
                 },

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -1,16 +1,16 @@
 const { expect } = require('@hapi/code')
 const Lab = require('@hapi/lab')
-const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
+const { it, describe, afterEach, beforeEach, before, after } = (exports.lab = Lab.script())
 
 const knexConfig = require('../../../knexfile')
 const db = require('knex')(knexConfig)
-
 const { init } = require('../../../src/server/init-server')
 const { config } = require('../../../src/server/env-config')
 const { Organisation } = require('../../../src/services')
 
 describe('v2/organisations', () => {
     let server
+
     beforeEach(async () => {
         server = await init(db, config)
     })
@@ -58,12 +58,23 @@ describe('v2/organisations', () => {
             expect(payload).to.include(['uuid'])
             expect(payload.id).to.be.undefined()
         })
+
+        it('should fail if no payload', async () => {
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/organisations',
+                payload: {}
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(400)
+        })
     })
 
     describe('add user to organisation', () => {
         it('should add user successfully', async () => {
             const [dhis2Org] = await Organisation.find(
-                { filter: { name: 'DHIS2' } },
+                { filter: { name: 'HISP Tanzania' } },
                 db
             )
 

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -1,6 +1,13 @@
 const { expect } = require('@hapi/code')
 const Lab = require('@hapi/lab')
-const { it, describe, afterEach, beforeEach, before, after } = (exports.lab = Lab.script())
+const {
+    it,
+    describe,
+    afterEach,
+    beforeEach,
+    before,
+    after,
+} = (exports.lab = Lab.script())
 
 const knexConfig = require('../../../knexfile')
 const db = require('knex')(knexConfig)
@@ -63,7 +70,7 @@ describe('v2/organisations', () => {
             const opts = {
                 method: 'POST',
                 url: '/api/v2/organisations',
-                payload: {}
+                payload: {},
             }
 
             const res = await server.inject(opts)
@@ -83,7 +90,7 @@ describe('v2/organisations', () => {
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/addUser`,
+                url: `/api/v2/organisations/${dhis2Org.uuid}/user`,
                 payload: {
                     email: 'appstore-api@dhis2.org',
                 },
@@ -104,7 +111,7 @@ describe('v2/organisations', () => {
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/addUser`,
+                url: `/api/v2/organisations/${dhis2Org.uuid}/user`,
                 payload: {
                     email: 'example-fail@dhis2.org',
                 },

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -83,7 +83,7 @@ describe('v2/organisations', () => {
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/add`,
+                url: `/api/v2/organisations/${dhis2Org.uuid}/addUser`,
                 payload: {
                     email: 'appstore-api@dhis2.org',
                 },
@@ -104,7 +104,7 @@ describe('v2/organisations', () => {
 
             const opts = {
                 method: 'POST',
-                url: `/api/v2/organisations/${dhis2Org.uuid}/add`,
+                url: `/api/v2/organisations/${dhis2Org.uuid}/addUser`,
                 payload: {
                     email: 'example-fail@dhis2.org',
                 },

--- a/test/routes/v2/organisations.js
+++ b/test/routes/v2/organisations.js
@@ -1,0 +1,106 @@
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
+
+const knexConfig = require('../../../knexfile')
+const db = require('knex')(knexConfig)
+
+const { init } = require('../../../src/server/init-server')
+const { config } = require('../../../src/server/env-config')
+const { Organisation } = require('../../../src/services')
+
+describe('v2/organisations', () => {
+    let server
+    beforeEach(async () => {
+        server = await init(db, config)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+    })
+
+    describe('get organisation', () => {
+        it('should get all organisations', async () => {
+            const opts = {
+                method: 'GET',
+                url: '/api/v2/organisations',
+            }
+
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+
+            const orgs = JSON.parse(res.payload)
+            expect(orgs).to.be.an.array()
+            expect(orgs[0]).to.include([
+                'uuid',
+                'name',
+                'slug',
+                'createdByUserUuid',
+            ])
+            expect(orgs[0]).to.not.include(['id', 'createdByUserId'])
+        })
+    })
+
+    describe('create organisation', async () => {
+        it('should create successfully', async () => {
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/organisations',
+                payload: {
+                    name: 'HISP Tanzania',
+                },
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(201)
+            const payload = JSON.parse(res.payload)
+            expect(payload).to.include(['uuid'])
+            expect(payload.id).to.be.undefined()
+        })
+    })
+
+    describe('add user to organisation', () => {
+        it('should add user successfully', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.uuid).to.be.a.string()
+
+            const opts = {
+                method: 'POST',
+                url: `/api/v2/organisations/${dhis2Org.uuid}/add`,
+                payload: {
+                    email: 'appstore-api@dhis2.org',
+                },
+            }
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+        })
+
+        it('should return 409 conflict if user does not exists', async () => {
+            const [dhis2Org] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+
+            expect(dhis2Org).to.not.be.undefined()
+            expect(dhis2Org.uuid).to.be.a.string()
+
+            const opts = {
+                method: 'POST',
+                url: `/api/v2/organisations/${dhis2Org.uuid}/add`,
+                payload: {
+                    email: 'example-fail@dhis2.org',
+                },
+            }
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(409)
+        })
+    })
+})

--- a/test/services/organisation.js
+++ b/test/services/organisation.js
@@ -84,8 +84,10 @@ describe('@services::Organisation', () => {
             expect(orgByUuid).to.not.be.null()
             expect(orgByUuid.users).to.be.an.array()
             const members = ['Mr Jenkins', 'Viktor Varland']
-            orgByUuid.users.forEach(u => {
-                expect(members).to.include(u.name)
+            members.forEach(name => {
+                const member = orgByUuid.users.find(u => u.name === name)
+                expect(member).to.not.be.undefined()
+                expect(member.uuid).to.be.a.string()
             })
         })
     })

--- a/test/services/organisation.js
+++ b/test/services/organisation.js
@@ -1,0 +1,278 @@
+const { expect } = require('@hapi/code')
+
+const Lab = require('@hapi/lab')
+
+const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
+
+const knexConfig = require('../../knexfile')
+const db = require('knex')(knexConfig)
+const getUserByEmail = require('../../src/data/getUserByEmail')
+
+const { ImageType } = require('../../src/enums')
+const { Organisation } = require('../../src/services')
+
+describe('@services::Organisation', () => {
+    describe('find', () => {
+        it('should find by name filter', async () => {
+            const filter = {
+                name: 'DHIS2',
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(orgs.length).to.be.equal(1)
+            expect(DHIS2App).to.not.be.null()
+            expect(DHIS2App.id).to.equal(1)
+        })
+
+        it('should find all organisations without a specified filter', async () => {
+            const orgs = ['DHIS2', 'World Health Organization']
+            const dbOrgs = await Organisation.find({}, db)
+            orgs.forEach(org => {
+                const dbOrg = dbOrgs.find(o => o.name === org.name)
+                expect(dbOrg).to.not.be.null()
+            })
+        })
+
+        it('should find organisations by user if filter has userUuid', async () => {
+            const user = await getUserByEmail('appstore-api@dhis2.org', db)
+            const filter = {
+                userUuid: user.uuid,
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(DHIS2App).to.not.be.null()
+        })
+
+        it('should work with multiple filters, ie userUuid and name', async () => {
+            const user = await getUserByEmail('appstore-api@dhis2.org', db)
+            const filter = {
+                name: 'DHIS2',
+                userUuid: user.uuid,
+            }
+            const orgs = await Organisation.find({ filter }, db)
+            const DHIS2App = orgs.find(o => o.name === 'DHIS2')
+            expect(DHIS2App).to.not.be.null()
+        })
+    })
+
+    describe('findByUuid', () => {
+        it('should throw if no existing uuid', async () => {
+            const org = Organisation.findByUuid(
+                'caacbb8c-01b4-4f98-8839-4aafafd46fee',
+                false,
+                db
+            )
+            await expect(org).to.reject()
+        })
+
+        it('should find organisations by uuid with users', async () => {
+            const orgs = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(orgs).to.have.length(1)
+            const dhis2Org = orgs[0]
+            expect(dhis2Org).to.not.be.null()
+            expect(dhis2Org.name).to.be.equal('DHIS2')
+            expect(dhis2Org.uuid).to.be.string()
+
+            const orgByUuid = await Organisation.findByUuid(
+                dhis2Org.uuid,
+                true,
+                db
+            )
+            expect(orgByUuid).to.not.be.null()
+            expect(orgByUuid.users).to.be.an.array()
+            const members = ['Mr Jenkins', 'Viktor Varland']
+            orgByUuid.users.forEach(u => {
+                expect(members).to.include(u.name)
+            })
+        })
+    })
+
+    describe('addUserById', async () => {
+        it('should successfully add user to organisation', async () => {
+            const userId = 2 //Erik, in WHO
+            const orgs = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.uuid).to.be.a.string()
+            expect(org.name).to.be.equal('DHIS2')
+
+            const res = await Organisation.addUserById(org.uuid, userId, db)
+
+            const orgWithUsers = await Organisation.findByUuid(
+                org.uuid,
+                true,
+                db
+            )
+            expect(orgWithUsers).to.include('name')
+            expect(orgWithUsers.name).to.be.equal('DHIS2')
+            expect(orgWithUsers.users).to.be.an.array()
+            const user = orgWithUsers.users.find(
+                u => u.name === 'Erik Arenhill'
+            )
+            expect(user).to.not.be.undefined()
+            expect(user.email).to.be.equal('erik@dhis2.org')
+        })
+
+        it('should throw if user already exists in organisation', async () => {
+            const userId = 2 //Erik, in WHO
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.uuid).to.be.a.string()
+            expect(org.name).to.be.equal('World Health Organization')
+            await expect(
+                Organisation.addUserById(org.uuid, userId, db)
+            ).to.reject(Error)
+        })
+
+        it('should work within a transaction', async () => {
+            const userId = 3 //Viktor, in DHIS2
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+
+            expect(orgs.length).to.be.equal(1)
+            const org = orgs[0]
+
+            expect(org.uuid).to.be.a.string()
+            expect(org.name).to.be.equal('World Health Organization')
+
+            const addUserAndGetOrg = async trx => {
+                await Organisation.addUserById(org.uuid, userId, trx)
+                const orgWithUsers = await Organisation.findByUuid(
+                    org.uuid,
+                    true,
+                    trx
+                )
+                return orgWithUsers
+            }
+
+            const orgWithUsers = await db.transaction(addUserAndGetOrg)
+            const newlyAddedUser = orgWithUsers.users.find(
+                u => u.name === 'Viktor Varland'
+            )
+            expect(newlyAddedUser).to.not.be.undefined()
+        })
+
+        it('should rollback within a transaction', async () => {
+            const userId = 2 //Erik, in WHO
+            const appstoreUserId = 1 // Appstore, in DHIS2
+            const orgs = await Organisation.find(
+                { filter: { name: 'World Health Organization' } },
+                db
+            )
+            const whoOrg = orgs[0]
+            expect(orgs.length).to.be.equal(1)
+
+            expect(whoOrg.uuid).to.be.a.string()
+            expect(whoOrg.name).to.be.equal('World Health Organization')
+
+            const addUser = async trx => {
+                // appstoreUser to who
+                await Organisation.addUserById(whoOrg.uuid, appstoreUserId, trx)
+                const orgWithUsers = await Organisation.findByUuid(
+                    whoOrg.uuid,
+                    true,
+                    trx
+                )
+                expect(orgWithUsers.users).to.be.an.array()
+                const newUser = orgWithUsers.users.find(
+                    u => u.name === 'Mr Jenkins'
+                )
+                expect(newUser).to.not.be.undefined()
+                // add Erik to WHO, should fail
+                await Organisation.addUserById(whoOrg.uuid, userId, trx)
+                return true
+            }
+
+            try {
+                const res = await db.transaction(addUser)
+            } catch (e) {
+                expect(e).to.be.an.error()
+                const orgWithUsers = await Organisation.findByUuid(
+                    whoOrg.uuid,
+                    true,
+                    db
+                )
+                expect(orgWithUsers.users).to.be.an.array()
+                const newUser = orgWithUsers.users.find(
+                    u => u.name === 'Mr Jenkins'
+                )
+                // should be rollbacked, so user should not have been added
+                expect(newUser).to.be.undefined()
+            }
+        })
+    })
+
+    describe('create', () => {
+        it('should create successfully', async () => {
+            const userId = 1 // appstore
+            const name = 'A new organisation'
+            const org = await Organisation.create({ userId, name }, db)
+            expect(org.id).to.a.number()
+            expect(org.uuid).to.be.a.string()
+        })
+
+        it('should fail to create when organisation is not unique', async () => {
+            const userId = 1 // appstore
+            const name = 'DHIS2'
+            const org = await expect(
+                Organisation.create({ userId, name }, db)
+            ).to.reject()
+        })
+
+        it('should work within a transaction', async () => {
+            const userId = 1 // appstore
+            const jenkins = await getUserByEmail('appstore-api@dhis2.org', db)
+            const name = 'Sintef'
+
+            const createAndGetOrg = async trx => {
+                const { id, uuid } = await Organisation.create(
+                    { userId, name },
+                    trx
+                )
+                expect(id).to.be.a.number()
+                expect(uuid).to.be.a.string()
+                return await Organisation.findByUuid(uuid, true, trx)
+            }
+
+            const org = await db.transaction(createAndGetOrg)
+            expect(org.name).to.be.equal(name)
+            expect(org.createdByUserUuid).to.be.equal(jenkins.uuid)
+        })
+    })
+
+    describe('setCreatedByUserId', () => {
+        it('should set userId successfully', async () => {
+            const user = await getUserByEmail('viktor@dhis2.org', db)
+            const orgs = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(orgs).to.have.length(1)
+            const org = orgs[0]
+            expect(org.createdByUserUuid).to.not.be.equal(user.uuid)
+            expect(user.id).to.be.equal(3)
+            await Organisation.setCreatedByUserId(org.uuid, user.id, db)
+
+            const [updatedOrg] = await Organisation.find(
+                { filter: { name: 'DHIS2' } },
+                db
+            )
+            expect(updatedOrg).to.not.be.undefined()
+            expect(updatedOrg.createdByUserUuid).to.be.equal(user.uuid)
+        })
+    })
+})

--- a/test/services/organisation.js
+++ b/test/services/organisation.js
@@ -219,7 +219,7 @@ describe('@services::Organisation', () => {
     describe('create', () => {
         it('should create successfully', async () => {
             const userId = 1 // appstore
-            const name = 'A new organisation'
+            const name = 'Unicef'
             const org = await Organisation.create({ userId, name }, db)
             expect(org.id).to.a.number()
             expect(org.uuid).to.be.a.string()


### PR DESCRIPTION
Introduces a small plugin that hooks into `onPreResponse`. This is used to map database errors such as "UniqueViolationError" to the correct Boom httpError (ie conflict in this case). We can also add our own errors, such as NotFoundError. It is not restricted to database-errors.
Previously all DB-errors were returned as 500-errors, which is not descriptive enough, as it might indicate user error.

It uses https://github.com/Vincit/db-errors to parse and check for database-errors, and then maps these error-classes to the correct Boom-error.

By default Hapi is stripping all error-messages and returns generic messages as to not leak information. For instance, Joi `ValidationErrors` are returned to the client as `400: Bad Request` with a generic message along the lines of `Invalid request payload input`.
To override this to get more information about the validation (eg what field failed etc.), we would need to re-throw the error in a `failAction`-handler. An idea is to re-throw it in development, and return just the error code with the reason phrase in production. See [this issue](https://github.com/hapijs/hapi/issues/3706) for more information regarding that.

Along those lines there's an option `preserveMessage` that can be set to `true` to include the original database message, which could be toggled in development. We absolutely do not want this enabled in production though, as these are the raw, internal database-errors.

**Note**: this is based on the #158 branch
