### PR TITLE
fix: users-with-organisation view

### DIFF
--- a/migrations/20200203182043_fix_view_users_with_organisations.js
+++ b/migrations/20200203182043_fix_view_users_with_organisations.js
@@ -1,0 +1,23 @@
+exports.up = async knex => {
+    await knex.raw('DROP VIEW users_with_organisations')
+    await knex.raw(`
+        CREATE VIEW users_with_organisations  
+        AS SELECT u.id AS user_id, u.name as user_name, u.email, o.name AS organisation_name, o.id AS organisation_id FROM users AS u 
+            INNER JOIN user_organisation AS dorg 
+                ON dorg.user_id = u.id
+            INNER JOIN organisation AS o 
+                ON o.id = dorg.organisation_id
+        `)
+}
+
+exports.down = async knex => {
+    await knex.raw('DROP VIEW users_with_organisations')
+    await knex.raw(`
+    CREATE VIEW users_with_organisations  
+    AS SELECT u.id AS user_id, u.name as user_name, u.email, o.name AS organisation_name, o.id AS organisation_id FROM users AS u 
+        INNER JOIN user_organisation AS dorg 
+            ON dorg.user_id = user_id 
+        INNER JOIN organisation AS o 
+            ON o.id = dorg.organisation_id
+    `)
+}


### PR DESCRIPTION
Small fix for the view. The view is not used by anything yet, but is handy to have.
I believe it's fine to update migrations directly like this when it's a bug-fix right?