### PR TITLE
feat: add support for using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json .
+RUN npm install --only=prod
+RUN npm run build
+
+COPY webpack.config.js .
+COPY knexfile.js .
+COPY seeds ./seeds
+COPY migrations ./migrations
+COPY static ./static
+COPY src ./src
+
+EXPOSE 3000
+
+#use prebuilt frontend by default
+ENV USE_PREBUILT_APP=1
+
+#listen to all interfaces
+ENV HOST=0.0.0.0
+
+CMD ["node", "src/main.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY package.json .
 RUN npm install --only=prod
 RUN npm run build
 
-COPY webpack.config.js .
 COPY knexfile.js .
 COPY seeds ./seeds
 COPY migrations ./migrations

--- a/src/server/compile-webapp.js
+++ b/src/server/compile-webapp.js
@@ -1,7 +1,6 @@
 const debug = require('debug')('apphub:server:boot:webapp')
 
 const webpack = require('webpack')
-const webpackConfig = require('../../webpack.config.js')
 
 exports.compile = () =>
     new Promise((resolve, reject) => {
@@ -11,6 +10,7 @@ exports.compile = () =>
         }
 
         debug('Compiling web application...')
+        const webpackConfig = require('../../webpack.config.js')
         webpack(webpackConfig, (err, stats) => {
             if (err) {
                 debug(err.stack || err)


### PR DESCRIPTION
This Dockerfile provides support for setting up an apphub instance without the database (using the env vars passed in for database). 
I will also providing the entire "apphub-cluster" within the docker-compose repository to spin up a postgres database along with the nodejs backend/frontend setup.

When this is merged I'd be happy to get some help setting up the auto-deploy/build stuff to automatically push the docker image to our registry