### PR TITLE
ci(docker): trim the docker image size

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,15 @@
     },
     "cypress-cucumber-preprocessor": {
         "nonGlobalStepDefinitions": true
-    }
+    },
+    "files": [
+        "config",
+        "seeds",
+        "src",
+        "static",
+        "migrations",
+        "knexfile.js",
+        ".ebextensions",
+        ".ebignore"
+    ]
 }


### PR DESCRIPTION
By using a multi-stage build to separate the build and serve phases, and
attempt to only include what we need to run in the serve phase, we can
cut down the image from 1.2 GB to 570 MB (unpacked).

Once we are using workspaces in this repo, we can further improve this
situation by separating the deps for the client and for the server. As
the client is precompiled the deps are included in the bundle, but now
they are listed in the dependencies array in package.json which means
the server will install them even when they aren't necessary.