### PR TITLE
fix: rename version filter querystring param

### DIFF
--- a/src/routes/v1/apps/handlers/getAllApprovedApps.js
+++ b/src/routes/v1/apps/handlers/getAllApprovedApps.js
@@ -36,7 +36,7 @@ module.exports = {
                 ? undefined
                 : request.query.channel || 'Stable'
 
-        const dhis2Version = request.query.dhis2Version || null
+        const dhis2Version = request.query.dhis_version || null
 
         debug(`Filtering by channel: '${channel}'`)
         debug(`Filtering by dhis2Version: '${dhis2Version}'`)

--- a/test/routes/index.js
+++ b/test/routes/index.js
@@ -84,7 +84,7 @@ describe('Get all published apps [v1]', async () => {
     it('should only return apps from the Stable channel supporting version 2.27', async () => {
         const injectOptions = {
             method: 'GET',
-            url: '/api/v1/apps?channel=Stable&dhis2Version=2.27',
+            url: '/api/v1/apps?channel=Stable&dhis_version=2.27',
         }
 
         const response = await server.inject(injectOptions)
@@ -109,7 +109,7 @@ describe('Get all published apps [v1]', async () => {
     it('should only return apps supporting version 2.27', async () => {
         const injectOptions = {
             method: 'GET',
-            url: '/api/v1/apps?channel=All&dhis2Version=2.27',
+            url: '/api/v1/apps?channel=All&dhis_version=2.27',
         }
 
         const response = await server.inject(injectOptions)


### PR DESCRIPTION
this is to match whats being used in the app management app