### PR TITLE
fix: add required validation to NewAppVersion form

### DIFF
--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -15,7 +15,7 @@ const DHISVersions = config.ui.dhisVersions
 
 const validate = values => {
     const errors = {}
-    const requiredFields = ['version', 'file', 'channel']
+    const requiredFields = ['version', 'file', 'channel', 'minVer', 'maxVer']
     requiredFields.forEach(field => {
         if (!values[field]) {
             errors[field] = 'Required'

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -15,7 +15,7 @@ const DHISVersions = config.ui.dhisVersions
 
 const validate = values => {
     const errors = {}
-    const requiredFields = ['version', 'file']
+    const requiredFields = ['version', 'file', 'channel']
     requiredFields.forEach(field => {
         if (!values[field]) {
             errors[field] = 'Required'

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -45,7 +45,13 @@ const NewAppVersionForm = props => {
 
     const loading = channels.loading
 
-    const DHISReleaseChannels = channels.list.map(c => c.name)
+    const releaseChannels = channels.list.map(channel => (
+        <MenuItem
+            key={channel.name}
+            value={channel.name}
+            primaryText={channel.name}
+        />
+    ))
 
     //TODO: add error instead of passing false to ErrorOrLoading
     return loading ? (
@@ -75,10 +81,11 @@ const NewAppVersionForm = props => {
             />
             <Field
                 name="channel"
-                component={formUtils.renderAutoCompleteField}
+                component={formUtils.renderSelectField}
                 label="Release channel"
-                dataSource={DHISReleaseChannels}
-            />
+            >
+                {releaseChannels}
+            </Field>
             <Field
                 name="demoUrl"
                 component={formUtils.renderTextField}

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -37,7 +37,7 @@ const NewAppVersionForm = props => {
             minDhisVersion: values.minVer,
             maxDhisVersion: values.maxVer,
             channel: values.channel,
-            demoUrl: values.demoUrl,
+            demoUrl: values.demoUrl || '',
         }
         const file = values.file[0]
         return props.submitted({ data, file: file })


### PR DESCRIPTION
add required form validation to "create new version" - to not crash when trying to submit with incorrect values in the POST to the backend