### PR TITLE
fix: make delete app work properly

### DIFF
--- a/server/src/routes/v1/apps/handlers/deleteApp.js
+++ b/server/src/routes/v1/apps/handlers/deleteApp.js
@@ -1,6 +1,8 @@
 const Boom = require('@hapi/boom')
 const Joi = require('@hapi/joi')
 
+const debug = require('debug')('apphub:server:routes:v1:handlers:deleteApp')
+
 const { deleteDir } = require('../../../../utils')
 const defaultFailHandler = require('../../defaultFailHandler')
 
@@ -24,7 +26,7 @@ module.exports = {
         },
     },
     handler: async (request, h) => {
-        //request.logger.info('In handler %s', request.path)
+        debug(`deleteApp : ${request.params.appId}`)
 
         if (!canDeleteApp(request, h)) {
             throw Boom.unauthorized()
@@ -35,13 +37,12 @@ module.exports = {
 
         const appId = request.params.appId
         const appRows = await getAppsById(appId, 'en', knex)
-        const item = appRows[0]
 
         const trx = await knex.transaction()
         try {
             await deleteApp(appId, knex, trx)
             await trx.commit()
-            await deleteDir(item.id)
+            await deleteDir(appId)
         } catch (err) {
             await trx.rollback()
             throw Boom.internal(err)

--- a/server/src/routes/v1/apps/handlers/deleteApp.js
+++ b/server/src/routes/v1/apps/handlers/deleteApp.js
@@ -38,6 +38,12 @@ module.exports = {
         const appId = request.params.appId
         const appRows = await getAppsById(appId, 'en', knex)
 
+        if (appRows.length === 0) {
+            throw Boom.notFound(
+                'The app you are trying to delete does not exist.'
+            )
+        }
+
         const trx = await knex.transaction()
         try {
             await deleteApp(appId, knex, trx)

--- a/server/test/routes/deleteApp.js
+++ b/server/test/routes/deleteApp.js
@@ -1,0 +1,83 @@
+const Lab = require('@hapi/lab')
+
+const { it, describe, beforeEach, afterEach } = (exports.lab = Lab.script())
+
+const { expect } = require('@hapi/code')
+
+const knexConfig = require('../../knexfile')
+const db = require('knex')(knexConfig)
+
+const { init } = require('../../src/server/init-server')
+
+const users = require('../../seeds/mock/users')
+
+describe('test delete app', () => {
+    const { config } = require('../../src/server/noauth-config')
+    let server
+    beforeEach(async () => {
+        config.auth.noAuthUserIdMapping = users[0].id
+        server = await init(db, config)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+    })
+
+    const sampleApp = {
+        name: 'DHIS2 Sample App',
+        description: 'A very nice sample description',
+        appType: 'APP',
+        sourceUrl: 'http://github.com',
+        developer: {
+            name: 'Foo Bar',
+            email: 'foobar@dhis2.org',
+            address: '',
+            organisation: 'The Largest Testing Organization In The World.',
+        },
+        versions: [
+            {
+                version: '1',
+                minDhisVersion: '2.25',
+                maxDhisVersion: '2.33',
+                demoUrl: 'https://www.dhis2.org',
+                channel: 'Stable',
+            },
+        ],
+        images: [],
+    }
+
+    it('should be able to delete an app', async () => {
+        //First upload the app, then delete it
+        const fs = require('fs')
+        const path = require('path')
+        const request = require('request-promise')
+
+        const form = {
+            app: JSON.stringify(sampleApp),
+            file: {
+                value: fs.createReadStream(
+                    path.join(__dirname, '../', 'sample-app.zip')
+                ),
+                options: {
+                    filename: 'sample-app.zip',
+                    contentType: 'application/zip',
+                },
+            },
+        }
+
+        const response = await request.post({
+            url: `http://${server.settings.host}:${server.settings.port}/api/apps`,
+            json: true,
+            formData: form,
+        })
+        expect(response.statusCode).to.equal(200)
+
+        const appId = response.uuid
+        const deleteResponse = await server.inject({
+            method: 'DELETE',
+            url: '/api/v1/apps/' + appId,
+        })
+
+        expect(deleteResponse.statusCode).to.equal(200)
+    })
+})

--- a/tools/clean.js
+++ b/tools/clean.js
@@ -1,0 +1,17 @@
+const request = require('request-promise-native')
+
+async function main() {
+    const targetUrl = 'http://localhost:3000/api'
+
+    const publishedAppsResponse = await request(targetUrl + '/apps')
+    const appsJson = JSON.parse(publishedAppsResponse)
+
+    const deleteRequestPromises = appsJson.map(app =>
+        request.delete(`${targetUrl}/apps/${app.id}`)
+    )
+
+    await Promise.all(deleteRequestPromises)
+    process.exit(0)
+}
+
+main()

--- a/tools/env.template
+++ b/tools/env.template
@@ -1,4 +1,4 @@
-#Required to use the clone script
+#Required for using the clone script if targeting an instance using auth0/jwt authentication
 AUTH0_SECRET=
 AUTH0_AUDIENCE=
 AUTH0_CLIENT_ID=


### PR DESCRIPTION
Incorrect id was used when deleting the directory where the app is stored, making the api request when deleting an app to fail