### PR TITLE
fix: allow admins to download all apps

### DIFF
--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line react/no-deprecated
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 
@@ -10,17 +11,13 @@ import {
     TableRowColumn,
 } from 'material-ui/Table'
 import FontIcon from 'material-ui/FontIcon'
-import IconMenu from 'material-ui/IconMenu'
 import IconButton from 'material-ui/IconButton'
 import MenuItem from 'material-ui/MenuItem'
-import Popover from 'material-ui/Popover'
 import TextField from 'material-ui/TextField'
 import Theme from '../../styles/theme'
 import SelectField from 'material-ui/SelectField'
 
 import merge from 'lodash/fp/merge'
-
-import config from '../../../config'
 
 import ErrorOrLoading from '../utils/ErrorOrLoading'
 
@@ -62,6 +59,9 @@ const TableIcon = ({ children }) => (
         {children}
     </FontIcon>
 )
+TableIcon.propTypes = {
+    children: PropTypes.array,
+}
 
 class VersionListEdit extends Component {
     constructor(props) {
@@ -90,7 +90,7 @@ class VersionListEdit extends Component {
         })
     }
 
-    handleCloseEditField(e) {
+    handleCloseEditField() {
         this.setState({
             ...this.state,
             open: !this.state.open,
@@ -210,11 +210,18 @@ class VersionListEdit extends Component {
 
         const values = merge(version, this.state.editedValues[version.id])
 
+        //auth0 stores the JWT token in localStorage
+        //as only authenticated users can edit an app, just assume this exists in this component
+        const token = localStorage.getItem('id_token')
+
+        //as we use hapi-auth-jwt2 in the backend, it allows us to pass the JWT in the querystring
+        const downloadUrlWithToken = `${values.downloadUrl}?token=${token}}`
+
         //TODO: add error instead of passing false to ErrorOrLoading
         return (
             <TableRow key={version.id}>
                 <TableRowColumn style={styles.firstColumn}>
-                    <a href={values.downloadUrl} title="Download">
+                    <a href={downloadUrlWithToken} title="Download">
                         <TableIcon>file_download</TableIcon>
                     </a>
                 </TableRowColumn>
@@ -233,6 +240,7 @@ class VersionListEdit extends Component {
                         <a
                             href={`${values.demoUrl}`}
                             target="_blank"
+                            rel="noopener noreferrer"
                             style={{ color: Theme.palette.primary1Color }}
                         >
                             Demo
@@ -325,7 +333,7 @@ class VersionListEdit extends Component {
 
         const versions = props.versionList
             .sort((a, b) => b.created - a.created)
-            .map((version, i) => {
+            .map(version => {
                 const editingRow =
                     this.state.editingFields.indexOf(version.id) > -1
 
@@ -400,9 +408,11 @@ class VersionListEdit extends Component {
 }
 
 VersionListEdit.propTypes = {
+    handleDelete: PropTypes.func.isRequired,
+    handleEdit: PropTypes.func.isRequired,
+    loadChannels: PropTypes.func.isRequired,
     versionList: PropTypes.array.isRequired,
-    handleDelete: PropTypes.func,
-    handleEdit: PropTypes.func,
+    channels: PropTypes.array,
 }
 VersionListEdit.defaultProps = {}
 

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -215,7 +215,7 @@ class VersionListEdit extends Component {
         const token = localStorage.getItem('id_token')
 
         //as we use hapi-auth-jwt2 in the backend, it allows us to pass the JWT in the querystring
-        const downloadUrlWithToken = `${values.downloadUrl}?token=${token}}`
+        const downloadUrlWithToken = `${values.downloadUrl}?token=${token}`
 
         //TODO: add error instead of passing false to ErrorOrLoading
         return (

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -23,6 +23,8 @@ import ErrorOrLoading from '../utils/ErrorOrLoading'
 
 import { loadChannels } from '../../actions/actionCreators'
 
+import { getAuth } from '../../utils/AuthService'
+
 const styles = {
     tableHeaderColumn: {
         paddingLeft: '12px',
@@ -212,7 +214,7 @@ class VersionListEdit extends Component {
 
         //auth0 stores the JWT token in localStorage
         //as only authenticated users can edit an app, just assume this exists in this component
-        const token = localStorage.getItem('id_token')
+        const token = getAuth().getToken()
 
         //as we use hapi-auth-jwt2 in the backend, it allows us to pass the JWT in the querystring
         const downloadUrlWithToken = `${values.downloadUrl}?token=${token}`

--- a/server/seeds/01_organisation-developers.js
+++ b/server/seeds/01_organisation-developers.js
@@ -46,6 +46,7 @@ exports.seed = async knex => {
     await knex('user_organisation').insert([
         { organisation_id: organisations[0].id, user_id: users[2].id }, //viktor -> dhis2
         { organisation_id: organisations[1].id, user_id: users[1].id }, //erik -> who
+        { organisation_id: organisations[0].id, user_id: users[1].id }, //erik -> dhis2, we need a user with multiple organisations to test that this also works
     ])
 
     console.log('Inserting user-organisations #02')

--- a/server/seeds/mock/users.js
+++ b/server/seeds/mock/users.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         id: '58262f57-4f38-45c5-a3c2-9e30ab3ba2da',
         email: 'apphub-api@dhis2.org',
-        name: 'Mr Jenkins',
+        name: 'tapps-bot',
     },
     {
         id: 'd30bfdae-ac6e-4ed4-8b2c-3cd1787922f4',

--- a/server/src/data/getOrganisationAppsByUserId.js
+++ b/server/src/data/getOrganisationAppsByUserId.js
@@ -1,0 +1,38 @@
+const debug = require('debug')('apphub:server:data:getOrganisationAppsByUserId')
+
+/**
+ * Returns all apps that a user has access to manage (the apps that belong to the organisations the user has access to)
+ *
+ * @param {string} id User id to get apps for
+ * @param {object} dbConnection db instance
+ * @returns {Promise<Array>}
+ */
+const getOrganisationAppsByUserId = async (id, knex) => {
+    if (!id) {
+        throw new Error('Missing/invalid paramter: id')
+    }
+
+    if (!knex) {
+        throw new Error('Missing parameter: knex')
+    }
+
+    const appIds = await knex('app')
+        .select('id')
+        .innerJoin(
+            'user_organisation',
+            'user_organisation.organisation_id',
+            'app.organisation_id'
+        )
+        .where({
+            'user_organisation.user_id': id,
+        })
+        .pluck('id')
+
+    debug('The user has access to apps:', appIds)
+
+    return knex('apps_view')
+        .select()
+        .where('app_id', 'in', appIds)
+}
+
+module.exports = getOrganisationAppsByUserId

--- a/server/src/data/index.js
+++ b/server/src/data/index.js
@@ -26,4 +26,5 @@ module.exports = {
     updateImageMeta: require('./updateImageMeta'),
     deleteAppVersion: require('./deleteAppVersion'),
     deleteChannel: require('./deleteChannel'),
+    getOrganisationAppsByUserId: require('./getOrganisationAppsByUserId'),
 }

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -63,9 +63,10 @@ module.exports = {
         const currentUser = await getCurrentUserFromRequest(request, db)
         const currentUserId = currentUser.id
 
+        const isManager = currentUserIsManager(request)
         const userApps = await getOrganisationAppsByUserId(currentUserId, db)
         const userCanEditApp =
-            userApps.map(app => app.app_id).indexOf(appId) !== -1
+            isManager || userApps.map(app => app.app_id).indexOf(appId) !== -1
 
         if (!userCanEditApp) {
             throw Boom.unauthorized()
@@ -110,7 +111,7 @@ module.exports = {
 
         let versionId = null
 
-        if (currentUserIsManager(request) || userCanEditApp) {
+        if (userCanEditApp) {
             const transaction = await db.transaction()
 
             const {

--- a/server/src/routes/v1/apps/handlers/editAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/editAppVersion.js
@@ -5,7 +5,10 @@ const {
     currentUserIsManager,
 } = require('../../../../security')
 
-const { updateAppVersion, getAppDeveloperId } = require('../../../../data')
+const {
+    updateAppVersion,
+    getOrganisationAppsByUserId,
+} = require('../../../../data')
 
 const EditAppVersionModel = require('../../../../models/v1/in/EditAppVersionModel')
 
@@ -38,12 +41,11 @@ module.exports = {
         const { appId, versionId } = request.params
 
         const currentUser = await getCurrentUserFromRequest(request, db)
-        const appDeveloperId = await getAppDeveloperId(appId, db)
+        const apps = await getOrganisationAppsByUserId(currentUser.id, db)
 
-        if (
-            currentUserIsManager(request) ||
-            appDeveloperId === currentUser.id
-        ) {
+        const hasDeveloperAccessToApp = apps.map(app => app.id).indexOf(appId)
+
+        if (currentUserIsManager(request) || hasDeveloperAccessToApp) {
             //can edit appversion
             const transaction = await db.transaction()
 

--- a/server/src/routes/v1/apps/handlers/getAppFile.js
+++ b/server/src/routes/v1/apps/handlers/getAppFile.js
@@ -11,7 +11,6 @@ const {
 } = require('../../../../security')
 
 module.exports = {
-    //unauthenticated endpoint returning the approved app for the specified id
     method: 'GET',
     path:
         '/v1/apps/download/{organisation_slug}/{appver_slug}/{app_version}/app.zip',

--- a/server/src/routes/v1/apps/handlers/getMyApps.js
+++ b/server/src/routes/v1/apps/handlers/getMyApps.js
@@ -28,8 +28,6 @@ module.exports = {
     handler: async (request, h) => {
         request.logger.info('In handler %s', request.path)
 
-        //TODO: implement fetching of apps for which the current user has access to, E.G. the organisations it belongs to
-
         try {
             const user = await getCurrentUserFromRequest(request, h.context.db)
             const apps = await getOrganisationAppsByUserId(

--- a/server/src/routes/v1/apps/handlers/getMyApps.js
+++ b/server/src/routes/v1/apps/handlers/getMyApps.js
@@ -1,8 +1,7 @@
 const debug = require('debug')('apphub:server:routes:handlers:v1:getMyApps')
-const Boom = require('@hapi/boom')
 const Joi = require('@hapi/joi')
 
-const { getAllAppsByDeveloperId } = require('../../../../data')
+const { getOrganisationAppsByUserId } = require('../../../../data')
 const { convertAppsToApiV1Format } = require('../formatting')
 
 const AppModel = require('../../../../models/v1/out/App')
@@ -33,7 +32,10 @@ module.exports = {
 
         try {
             const user = await getCurrentUserFromRequest(request, h.context.db)
-            const apps = await getAllAppsByDeveloperId(user.id, h.context.db)
+            const apps = await getOrganisationAppsByUserId(
+                user.id,
+                h.context.db
+            )
             return convertAppsToApiV1Format(apps, request)
         } catch (err) {
             debug(err)

--- a/server/src/security/index.js
+++ b/server/src/security/index.js
@@ -5,7 +5,7 @@ const debug = require('debug')('apphub:server:security')
  */
 const isAuthenticated = request => {
     try {
-        debug('isAuthenticated:', request.auth.isAuthenticated)
+        debug('isAuthenticated:', request.auth)
         return request.auth.isAuthenticated === true
     } catch (err) {
         debug('isAuthenticated error:', err)

--- a/server/src/security/index.js
+++ b/server/src/security/index.js
@@ -5,8 +5,10 @@ const debug = require('debug')('apphub:server:security')
  */
 const isAuthenticated = request => {
     try {
+        debug('isAuthenticated:', request.auth.isAuthenticated)
         return request.auth.isAuthenticated === true
     } catch (err) {
+        debug('isAuthenticated error:', err)
         return false
     }
 }
@@ -18,6 +20,7 @@ const isAuthenticated = request => {
  */
 const hasRole = (request, role) => {
     try {
+        debug('hasRole:', request.auth.credentials.roles)
         return request.auth.credentials.roles.indexOf(role) !== -1
     } catch (err) {
         return false
@@ -27,9 +30,8 @@ const hasRole = (request, role) => {
 /**
  * Checks if the user on the request has permissions to delete an app
  * @param {*} request
- * @param {*} hapi
  */
-const canDeleteApp = (request, hapi) =>
+const canDeleteApp = request =>
     isAuthenticated(request) && hasRole(request, 'ROLE_MANAGER')
 
 /**
@@ -37,36 +39,33 @@ const canDeleteApp = (request, hapi) =>
  * @param {*} request
  * @param {*} hapi
  */
-const canChangeAppStatus = (request, hapi) =>
+const canChangeAppStatus = request =>
     isAuthenticated(request) && hasRole(request, 'ROLE_MANAGER')
 
 /**
  * Checks if the user on the request has permissions to create an app version
  * @param {*} request
- * @param {*} hapi
  */
-const canCreateAppVersion = (request, hapi) => isAuthenticated(request)
+const canCreateAppVersion = request => isAuthenticated(request)
 
 /**
  * Checks if the user on the request has permissions to create an app
  * @param {*} request
- * @param {*} hapi
  */
-const canCreateApp = (request, hapi) => isAuthenticated(request)
+const canCreateApp = request => isAuthenticated(request)
 
 /**
  * Checks if the user on the request has permissions to see all apps
  * @param {*} request
- * @param {*} hapi
  */
-const canSeeAllApps = (request, hapi) =>
+const canSeeAllApps = request =>
     isAuthenticated(request) && hasRole(request, 'ROLE_MANAGER')
 
-const currentUserIsManager = (request, hapi) =>
+const currentUserIsManager = request =>
     isAuthenticated(request) && hasRole(request, 'ROLE_MANAGER')
 
-const getCurrentUserFromRequest = async request => {
-    return new Promise(async (resolve, reject) => {
+const getCurrentUserFromRequest = request => {
+    return new Promise((resolve, reject) => {
         try {
             const user = {
                 id: request.auth.credentials.userId,


### PR DESCRIPTION
this adds possibility to authenticate the user on the download endpoint for apps, and passes the JWT-token in the querystring on download links when viewing an unapproved/rejected app in the admin/edit-version of the gui.

This also brings in some changes to how a developer is determined to have access to an app. Previously it would only allow edit-access if being the developer that uploaded the app, now it will allow access to all apps which you belong to the same organisation it's connected to.

Also tested that you can retreive "myapps" with a user having multiple organisations

Adds transaction/rollback beforeEach/afterEach organisation unit tests