### PR TITLE
fix(createapp): add user to organisation if org does note xist

### DIFF
--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -120,6 +120,14 @@ module.exports = {
                     knex,
                     trx
                 )
+                await addUserToOrganisation(
+                    {
+                        userId: currentUserId,
+                        organisationId: organisation.id,
+                    },
+                    knex,
+                    trx
+                )
             } else {
                 organisation = organisations[0]
                 if (currentUserId !== organisation.created_by_user_id) {


### PR DESCRIPTION

We need to add the current user to the created organisation, or else the uploading user won't have access to the newly created app.