### PR TITLE
fix(clone): keep owner access

### DIFF
--- a/client/default.config.js
+++ b/client/default.config.js
@@ -10,20 +10,7 @@ module.exports = {
         baseAppName: '/',
     },
     ui: {
-        dhisVersions: [
-            '2.32',
-            '2.31',
-            '2.30',
-            '2.29',
-            '2.28',
-            '2.27',
-            '2.26',
-            '2.25',
-            '2.24',
-            '2.23',
-            '2.22',
-            '2.21',
-        ],
+        dhisVersions: ['2.34', '2.33', '2.32', '2.31', '2.30', '2.29', '2.28'],
         appStatusToDisplayName: {
             NOT_APPROVED: 'Rejected',
             PENDING: 'Pending',

--- a/client/development.config.js
+++ b/client/development.config.js
@@ -10,20 +10,7 @@ module.exports = {
         baseAppName: '/',
     },
     ui: {
-        dhisVersions: [
-            '2.32',
-            '2.31',
-            '2.30',
-            '2.29',
-            '2.28',
-            '2.27',
-            '2.26',
-            '2.25',
-            '2.24',
-            '2.23',
-            '2.22',
-            '2.21',
-        ],
+        dhisVersions: ['2.34', '2.33', '2.32', '2.31', '2.30', '2.29', '2.28'],
         appStatusToDisplayName: {
             NOT_APPROVED: 'Rejected',
             PENDING: 'Pending',

--- a/client/test/config/configResolver.spec.js
+++ b/client/test/config/configResolver.spec.js
@@ -1,6 +1,6 @@
+/* eslint-disable no-undef */
 import ConfigImport, { getConfig } from '../../config/configResolver'
 import DirectDefaultConfig from '../../default.config.js'
-import fs from 'fs'
 import merge from 'lodash/merge'
 const defaultConfigPath = '../../config/'
 const Config = ConfigImport.default
@@ -27,7 +27,7 @@ describe('ConfigResolver', () => {
     describe('getConfig()', () => {
         const override = {
             routes: { baseAppName: 'baseAppName' },
-            ui: { dhisVersions: ['2.32'] },
+            ui: { dhisVersions: ['2.34'] },
         }
         const addition = {
             another: 'setting',

--- a/server/src/data/index.js
+++ b/server/src/data/index.js
@@ -27,4 +27,7 @@ module.exports = {
     deleteAppVersion: require('./deleteAppVersion'),
     deleteChannel: require('./deleteChannel'),
     getOrganisationAppsByUserId: require('./getOrganisationAppsByUserId'),
+    createAppStatus: require('./createAppStatus'),
+    createAppVersion: require('./createAppVersion'),
+    createLocalizedAppVersion: require('./createLocalizedAppVersion'),
 }

--- a/server/src/models/v1/in/CreateAppModel.js
+++ b/server/src/models/v1/in/CreateAppModel.js
@@ -6,9 +6,7 @@ const CreateModelAppData = Joi.object().keys({
     name: Joi.string(),
     description: Joi.string().allow(''),
     appType: Joi.string().valid(...AppTypes),
-    sourceUrl: Joi.string()
-        .uri()
-        .allow(''),
+    sourceUrl: Joi.string().uri().allow(''),
     developer: Joi.object().keys({
         name: Joi.string(),
         email: Joi.string().email(),
@@ -30,6 +28,12 @@ const CreateModelAppData = Joi.object().keys({
             description: Joi.string().allow('', null),
         })
     ),
+    owner: Joi.object({
+        email: Joi.string()
+            .email()
+            .required(),
+        name: Joi.string().required(),
+    }),
 })
 
 const payloadSchema = Joi.object({

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -177,7 +177,7 @@ module.exports = {
                 //1. either it's a manager uploading the app
                 //2. or the owner e-mail is the same as verified on the request
                 const shouldAddUserToOrg =
-                    isManager || appOwner.email === currentUser.email
+                    isManager || email === currentUser.email
 
                 if (shouldAddUserToOrg && appOwner === null) {
                     appOwner = await createUser(

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -167,7 +167,7 @@ module.exports = {
 
             if (appJsonPayload.owner) {
                 const { email, name } = appJsonPayload.owner
-                let appOwner = await getUserByEmail(email, knex)
+                let appOwner = await getUserByEmail(email, trx)
 
                 if (appOwner === null) {
                     appOwner = await createUser(

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -136,14 +136,11 @@ module.exports = {
             } else {
                 organisation = organisations[0]
 
-                const org = await OrganisationService.findOne(
+                const isMember = await OrganisationService.hasUser(
                     organisation.id,
-                    true,
+                    currentUserId,
                     trx
                 )
-
-                const isMember =
-                    org.users.findIndex(u => u.id === currentUserId) > -1
 
                 if (!isMember && !isManager) {
                     throw Boom.unauthorized(

--- a/server/src/routes/v1/apps/handlers/editApp.js
+++ b/server/src/routes/v1/apps/handlers/editApp.js
@@ -46,10 +46,11 @@ module.exports = {
             db
         )
         const userCanEditApp =
-            appsUserCanEdit.filter(app => app.id === request.params.appId)
+            appsUserCanEdit.filter(app => app.app_id === request.params.appId)
                 .length > 0
 
         debug('appsUserCanEdit:', appsUserCanEdit)
+        debug('userCanEditApp:', userCanEditApp)
 
         if (currentUserIsManager(request) || userCanEditApp) {
             //can edit app

--- a/server/src/services/organisation.js
+++ b/server/src/services/organisation.js
@@ -133,6 +133,17 @@ const remove = async (id, db) => {
         .delete()
 }
 
+const hasUser = async (id, userId, knex) => {
+    const hasUser = await knex('user_organisation')
+        .select(1)
+        .where({
+            organisation_id: id,
+            user_id: userId,
+        })
+        .limit(1)
+    return hasUser.length > 0
+}
+
 module.exports = {
     find,
     findOne,
@@ -141,4 +152,5 @@ module.exports = {
     update,
     remove,
     removeUser,
+    hasUser,
 }

--- a/tools/clone.js
+++ b/tools/clone.js
@@ -26,7 +26,7 @@ const findAppByName = (name, list) => {
 
 async function main() {
     const sourceUrl = 'https://play.dhis2.org/appstore/api/apps'
-    const targetUrl = 'https://staging.apps.dhis2.org/api'
+    const targetUrl = 'http://localhost:3000/api'
     const authToken = await getAuth0Token()
 
     const publishedApps = await request(sourceUrl)
@@ -36,7 +36,7 @@ async function main() {
     let existingAppsAtTarget = JSON.parse(targetApps)
 
     //TODO: make configurable
-    const cleanTarget = false
+    const cleanTarget = true
 
     if (cleanTarget) {
         for (let i = 0; i < existingAppsAtTarget.length; ++i) {

--- a/tools/clone.js
+++ b/tools/clone.js
@@ -14,29 +14,74 @@ const uploadImages = require('./helpers/uploadImages')
 
 const errors = []
 
+const findAppByName = (name, list) => {
+    for (let i = 0; i < list.length; ++i) {
+        const app = list[i]
+        if (app.name === name) {
+            return app
+        }
+    }
+    return null
+}
+
 async function main() {
     const sourceUrl = 'https://play.dhis2.org/appstore/api/apps'
-    const targetUrl = 'http://localhost:3000/api'
+    const targetUrl = 'https://staging.apps.dhis2.org/api'
     const authToken = await getAuth0Token()
 
     const publishedApps = await request(sourceUrl)
     const appsJson = JSON.parse(publishedApps)
 
+    let targetApps = await request(`${targetUrl}/apps`)
+    let existingAppsAtTarget = JSON.parse(targetApps)
+
+    //TODO: make configurable
+    const cleanTarget = false
+
+    if (cleanTarget) {
+        for (let i = 0; i < existingAppsAtTarget.length; ++i) {
+            const app = existingAppsAtTarget[i]
+            console.log(`Deleting app '${app.name}'`)
+            await request.delete({
+                url: `${targetUrl}/apps/${app.id}`,
+                headers: {
+                    Authorization: 'Bearer ' + authToken,
+                },
+            })
+        }
+        //refresh existing apps
+        targetApps = await request(`${targetUrl}/apps`)
+        existingAppsAtTarget = JSON.parse(targetApps)
+    }
+
     for (let i = 0; i < appsJson.length; ++i) {
         const app = appsJson[i]
+
+        const existingApp = findAppByName(app.name, existingAppsAtTarget)
+
+        if (existingApp !== null) {
+            //app exists, but all versions?
+            console.log(
+                `App "${app.name}" already exists at target/destination, skipping it.`
+            )
+            continue
+        }
 
         if (!fs.existsSync('./apps')) {
             fs.mkdirSync('./apps')
         }
 
-        const dir = './apps/' + app.name
+        const dir = './apps/' + app.name.replace('/', '-')
         if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir)
+            fs.mkdirSync(dir, '0777', true)
         }
 
-        console.log(`Downloading app: ${app.name}`)
+        console.log(`Downloading app: ${app.name} to ${dir}`)
 
         if (!app.developer.email || app.developer.email == '') {
+            console.log(`Skipping app because no developer email is set`)
+
+            //also store this in an array so we can summarize errors after the run has completed
             errors.push(`${app.name} | No developer email set. Skipping.`)
             continue
         }
@@ -66,6 +111,7 @@ async function main() {
         //create app with first version
         const appVersion = app.versions[0]
         const appVersionFile = path.join(dir, appVersion.version + '.zip')
+
         const form = {
             app: JSON.stringify(appBase),
             file: {

--- a/tools/helpers/downloadImages.js
+++ b/tools/helpers/downloadImages.js
@@ -11,12 +11,13 @@ module.exports = async (dir, app) => {
         const fileName = appImage.id + fileExtension
 
         return new Promise((resolve, reject) => {
-            const imageFile = fs.createWriteStream(path.join(dir, fileName))
+            const target = path.join(dir, fileName)
+            const imageFile = fs.createWriteStream(target)
             request(appImage.imageUrl)
                 .pipe(imageFile)
                 .on('finish', () => {
                     console.log(
-                        `Successfully downloaded image: ${appImage.imageUrl} => ${fileName}`
+                        `Successfully downloaded image: ${appImage.imageUrl} => ${target}`
                     )
                     resolve()
                 })

--- a/tools/helpers/getAuthToken.js
+++ b/tools/helpers/getAuthToken.js
@@ -1,13 +1,15 @@
 const request = require('request-promise-native')
 
-module.exports = async () => {
-    const url = 'https://dhis2.eu.auth0.com/oauth/token'
+const url = 'https://dhis2.eu.auth0.com/oauth/token'
+
+const getM2MAuthToken = async () => {
     const payload = JSON.stringify({
         client_id: process.env.AUTH0_CLIENT_ID,
         client_secret: process.env.AUTH0_SECRET,
         audience: process.env.AUTH0_AUDIENCE,
         grant_type: 'client_credentials',
     })
+    console.log(payload)
     const tokenResponse = await request.post({
         url,
         headers: {
@@ -19,4 +21,26 @@ module.exports = async () => {
     const tokenJson = JSON.parse(tokenResponse)
 
     return tokenJson.access_token
+}
+
+const getManagementAuthToken = async () => {
+    const payload = JSON.stringify({
+        client_id: process.env.AUTH0_MANAGEMENT_CLIENT_ID,
+        client_secret: process.env.AUTH0_MANAGEMENT_SECRET,
+        audience: process.env.AUTH0_MANGAGEMENT_AUDIENCE,
+        grant_type: 'client_credentials',
+    })
+
+    const tokenResponse = await request.post({
+        url,
+        headers: { 'content-type': 'application/json' },
+        body: payload,
+    })
+
+    return JSON.parse(tokenResponse).access_token
+}
+
+module.exports = {
+    getM2MAuthToken,
+    getManagementAuthToken,
 }

--- a/tools/helpers/getAuthToken.js
+++ b/tools/helpers/getAuthToken.js
@@ -9,7 +9,6 @@ const getM2MAuthToken = async () => {
         audience: process.env.AUTH0_AUDIENCE,
         grant_type: 'client_credentials',
     })
-    console.log(payload)
     const tokenResponse = await request.post({
         url,
         headers: {


### PR DESCRIPTION
Note that this builds upon #310 , so that should probably be merged first.

To keep access for the uploading user we need to add that user to the organisation the app is uploaded to. The developer-user and owner may be completely different emails/users. Normally, when uploading an app, the user uploading the app are the owner, and thus added to that organisation (fixed in #314 ). However when uploading apps with the clone script, the M2M user will be the current user, and therefore the user that uploaded the app in the previous appstore won't have access unless the developer email is the same.

The fix is not pretty to be honest. I've modified the v1 API, but this is not breaking as it just adds a new object that can be attached to the app. This object describes the owner of the app, so it can "override" the current user as the owner of the app with the attached information.

The clone script uses the M2M "API explorer client" to get the information about the original uploader from Auth0 (using the owner-field that has the oauth ID for the original uploader). 


A pretty useful utility when testing access for different users is to go to `Users` in Auth0, and select `Sign in as user`. Click advanced and add `openid roles user_id email profile` as Scope. You can even use localhost as the callback-url.

If you are testing this, you need to add the `AUTH0_MANAGEMENT_SECRET`, `AUTH0_MANGAGEMENT_AUDIENCE` and `AUTH0_MANAGEMENT_CLIENT_ID` keys in the .env-file in the tools directory. The values are found in auth0 under the `API Explorer Client` application. 