### PR TITLE
fix: appcard height

### DIFF
--- a/client/src/components/appCards/AppCardItem.jsx
+++ b/client/src/components/appCards/AppCardItem.jsx
@@ -41,7 +41,7 @@ const AppItem = props => {
     }
 
     return (
-        <div data-test="app-card">
+        <div data-test="app-card" style={{ height: '100%' }}>
             <Card style={{ height: '100%' }}>
                 <Link to={`/app/${id}`}>
                     <CardMedia style={mediaStyle} />


### PR DESCRIPTION
After the introduction of the div with `data-test` attribute, the appcards did not have the same height in certain viewport widths. 