### PR TITLE
fix: upload and deletion of logo

### DIFF
--- a/server/src/data/deleteAppMedia.js
+++ b/server/src/data/deleteAppMedia.js
@@ -1,0 +1,22 @@
+const debug = require('debug')('apphub:server:data:deleteMedia')
+/**
+ * Deletes a media with the specified id
+ *
+ * @param {string} id id for the media to delete
+ * @param {object} knex db instance
+ * @returns {Promise}
+ */
+const deleteAppMedia = async (id, knex, transaction) => {
+    try {
+        await knex('app_media')
+            .transacting(transaction)
+            .where('id', id)
+            .del()
+        debug('deleted app_media', id)
+    } catch (err) {
+        debug(err)
+        throw new Error(`Could not delete app media for: ${id}`)
+    }
+}
+
+module.exports = deleteAppMedia

--- a/server/src/data/index.js
+++ b/server/src/data/index.js
@@ -8,6 +8,7 @@ module.exports = {
     createUser: require('./createUser'),
     deleteApp: require('./deleteApp'),
     deleteMedia: require('./deleteMedia'),
+    deleteAppMedia: require('./deleteAppMedia'),
     deleteOrganisation: require('./deleteOrganisation'),
     getAllAppsByLanguage: require('./getAllAppsByLanguage'),
     getAllAppsByDeveloperId: require('./getAllAppsByDeveloperId'),

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -316,7 +316,7 @@ module.exports = {
                 if (imageInfo) {
                     ;({ caption, description } = imageInfo)
                 }
-                const { id, media_id } = await addAppMedia(
+                const { id: appMedia_id, media_id } = await addAppMedia(
                     {
                         userId: requestUserId,
                         appId: appId,
@@ -331,9 +331,9 @@ module.exports = {
                 )
 
                 debug(
-                    `Logo inserted with app_media_id '${id}' and media_id: '${media_id}`
+                    `Logo inserted with app_media_id '${appMedia_id}' and media_id: '${media_id}`
                 )
-                iconId = media_id
+                iconId = appMedia_id
             }
         } catch (err) {
             debug('ROLLING BACK TRANSACTION')

--- a/server/src/routes/v1/apps/handlers/deleteImage.js
+++ b/server/src/routes/v1/apps/handlers/deleteImage.js
@@ -8,14 +8,14 @@ const {
 const {
     getAppDeveloperId,
     getAppMedia,
-    deleteMedia,
+    deleteAppMedia,
 } = require('../../../../data')
 
 const { deleteFile } = require('../../../../utils')
 
 module.exports = {
     method: 'DELETE',
-    path: '/v1/apps/{appId}/images/{mediaId}',
+    path: '/v1/apps/{appId}/images/{appMediaId}',
     config: {
         auth: 'token',
         tags: ['api', 'v1'],
@@ -33,7 +33,7 @@ module.exports = {
 
         const db = h.context.db
 
-        const { mediaId, appId } = request.params
+        const { appMediaId, appId } = request.params
 
         const currentUser = await getCurrentUserFromRequest(request, db)
         const appDeveloperId = await getAppDeveloperId(appId, db)
@@ -45,13 +45,11 @@ module.exports = {
             const transaction = await db.transaction()
 
             try {
-                const { media_id } = await getAppMedia(mediaId, db)
-
-                await deleteMedia(media_id, db, transaction)
+                await deleteAppMedia(appMediaId, db, transaction)
 
                 await transaction.commit()
 
-                await deleteFile(appId, media_id)
+                await deleteFile(appId, appMediaId)
             } catch (err) {
                 await transaction.rollback()
                 throw Boom.internal(err)


### PR DESCRIPTION
Fixes upload of logo and deletion of logo introduced in #285 .

When uploading a logo the logo was saved with `media_id` instead of `app_media_id`. The app is given `app_media_id` for the ID of images so the `getAppMedia`-endpoint would return 404 since it tried to get the image by the `app_media_id` these IDs are obviously different.

The same was kind of true for deletion of media. The naming of IDs was very confusing here, as it tried to get the `media_id` using the `mediaId`. However, it also deleted from `media`-table instead of `app_media`-table - which does not have cascading.

The result is that we're now saving images with `app_media_id` instead of `media_id`. I'm unsure of the original thought behind this and which IDs we should expose in the API and which we should use when saving the images. We can easily switch these to using the `media_id`, however the `app_view` is exposing the `app_media_id`, so this felt more natural to use.
