### PR TITLE
fix: use slug + version as filename on download

### DIFF
--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -57,7 +57,7 @@ const convertAppToV1AppVersion = (app, serverUrl) => {
         created: +new Date(app.version_created_at),
 
         demoUrl: app.demo_url || '',
-        downloadUrl: `${serverUrl}/v1/apps/download/${app.organisation_slug}/${app.appver_slug}/${app.version}/app.zip`,
+        downloadUrl: `${serverUrl}/v1/apps/download/${app.organisation_slug}/${app.appver_slug}_${app.version}.zip`,
         id: app.version_id,
         lastUpdated: +new Date(app.version_created_at),
         maxDhisVersion: app.max_dhis2_version,

--- a/server/src/routes/v1/apps/handlers/getAppFile.js
+++ b/server/src/routes/v1/apps/handlers/getAppFile.js
@@ -90,6 +90,10 @@ module.exports = {
         return h
             .response(file.Body)
             .type('application/zip')
+            .header(
+                'Content-Disposition',
+                `attachment; filename=${item.appver_slug}_${item.version}.zip;`
+            )
             .header('Content-length', file.ContentLength)
     },
 }

--- a/server/src/routes/v1/apps/handlers/getAppFile.js
+++ b/server/src/routes/v1/apps/handlers/getAppFile.js
@@ -13,7 +13,7 @@ const {
 module.exports = {
     method: 'GET',
     path:
-        '/v1/apps/download/{organisation_slug}/{appver_slug}/{app_version}/app.zip',
+        '/v1/apps/download/{organisation_slug}/{appver_slug}_{app_version}.zip',
     config: {
         auth: { strategy: 'token', mode: 'try' },
         tags: ['api', 'v1'],

--- a/server/test/routes/index.js
+++ b/server/test/routes/index.js
@@ -53,7 +53,7 @@ describe('Get all published apps [v1]', async () => {
             'https://play.dhis2.org/2.30/api/apps/Immunization-analysis/index.html#!/report'
         )
         expect(whoApp[0].versions[0].downloadUrl).to.be.equal(
-            'http://localhost:3000/api/v1/apps/download/world-health-organization/a-nice-app-by-who/1.0/app.zip'
+            'http://localhost:3000/api/v1/apps/download/world-health-organization/a-nice-app-by-who_1.0.zip'
         )
 
         expect(whoApp[0].sourceUrl).to.be.equal(


### PR DESCRIPTION
should resolve https://jira.dhis2.org/browse/DHIS2-9256 if the backend makes use of the content-disposition filename from header