### PR TITLE
fix: verify developer permission correctly on several API endpoints

### DIFF
--- a/server/src/routes/v1/apps/handlers/deleteAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/deleteAppVersion.js
@@ -1,11 +1,17 @@
 const Boom = require('@hapi/boom')
+const debug = require('debug')(
+    'apphub:server:routes:handlers:v1:deleteAppVersion'
+)
 
 const {
     getCurrentUserFromRequest,
     currentUserIsManager,
 } = require('../../../../security')
 
-const { getAppDeveloperId, deleteAppVersion } = require('../../../../data')
+const {
+    deleteAppVersion,
+    getOrganisationAppsByUserId,
+} = require('../../../../data')
 
 const { deleteFile } = require('../../../../utils')
 
@@ -32,11 +38,15 @@ module.exports = {
         const { appId, versionId } = request.params
 
         const currentUser = await getCurrentUserFromRequest(request, db)
-        const appDeveloperId = await getAppDeveloperId(appId, db)
 
         const isManager = currentUserIsManager(request)
+        const userApps = await getOrganisationAppsByUserId(currentUser.id, db)
+        const userCanDeleteVersion =
+            isManager || userApps.map(app => app.app_id).indexOf(appId) !== -1
 
-        if (isManager || appDeveloperId === currentUser.id) {
+        debug('isManager:', isManager)
+        debug('userCanDeleteVersion:', userCanDeleteVersion)
+        if (isManager || userCanDeleteVersion) {
             //can edit app
             const transaction = await db.transaction()
 

--- a/server/src/routes/v1/apps/handlers/deleteImage.js
+++ b/server/src/routes/v1/apps/handlers/deleteImage.js
@@ -1,11 +1,16 @@
 const Boom = require('@hapi/boom')
 
+const debug = require('debug')('apphub:server:routes:handlers:v1:deleteImage')
+
 const {
     getCurrentUserFromRequest,
     currentUserIsManager,
 } = require('../../../../security')
 
-const { getAppDeveloperId, deleteAppMedia } = require('../../../../data')
+const {
+    deleteAppMedia,
+    getOrganisationAppsByUserId,
+} = require('../../../../data')
 
 const { deleteFile } = require('../../../../utils')
 
@@ -32,11 +37,16 @@ module.exports = {
         const { appMediaId, appId } = request.params
 
         const currentUser = await getCurrentUserFromRequest(request, db)
-        const appDeveloperId = await getAppDeveloperId(appId, db)
-
         const isManager = currentUserIsManager(request)
 
-        if (isManager || appDeveloperId === currentUser.id) {
+        const userApps = await getOrganisationAppsByUserId(currentUser.id, db)
+        const canDeleteImage =
+            isManager || userApps.map(app => app.app_id).indexOf(appId) !== -1
+
+        debug('isManager:', isManager)
+        debug('canDeleteImage:', canDeleteImage)
+
+        if (canDeleteImage) {
             //can edit app
             const transaction = await db.transaction()
 


### PR DESCRIPTION
previously a developer (non manager) could not delete an app-version, upload image, or delete an image on his own apps after it was created the first time. This PR fixes all those

https://jira.dhis2.org/browse/HUB-84
https://jira.dhis2.org/browse/HUB-85
https://jira.dhis2.org/browse/HUB-86