### PR TITLE
fix(apiroutes): add 404-handler for /api

### DIFF
--- a/server/src/plugins/apiRoutes.js
+++ b/server/src/plugins/apiRoutes.js
@@ -11,12 +11,14 @@ const routes = require('../routes/index.js')
 const defaultNotFoundRoute = {
     method: 'GET',
     path: '/{p*}',
-    handler: () => {
-        return {
-            statusCode: 404,
-            error: 'Not Found',
-            message: 'Not Found',
-        }
+    handler: (request, h) => {
+        return h
+            .response({
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Not Found',
+            })
+            .code(404)
     },
 }
 

--- a/server/src/plugins/apiRoutes.js
+++ b/server/src/plugins/apiRoutes.js
@@ -6,6 +6,20 @@ const createUserValidationFunc = require('../security/createUserValidationFunc')
 
 const routes = require('../routes/index.js')
 
+// This is needed to override staticFrontendRoutes's catch-all route
+// so that 404s under /api is not redirected to index.html
+const defaultNotFoundRoute = {
+    method: 'GET',
+    path: '/{p*}',
+    handler: () => {
+        return {
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Not Found',
+        }
+    },
+}
+
 const apiRoutesPlugin = {
     name: 'DHIS2 App Hub Backend',
     register: async (server, options) => {
@@ -72,7 +86,7 @@ const apiRoutesPlugin = {
             }
         }
 
-        server.route(routes)
+        server.route([...routes, defaultNotFoundRoute])
     },
 }
 


### PR DESCRIPTION
Adds a catch-all route for `/api` that returns the default `404-error`. Previously the  catch-all route in staticFrontendRoutes would also catch 404 under `/api`, and return `index.html`. 

http://localhost:3000/api/appz -> would previously return `index.html`. Now it returns 404.