### PR TITLE
fix(download): encode download-components, forbid _ in version

### DIFF
--- a/server/migrations/20200924140557_version-replace-underscore.js
+++ b/server/migrations/20200924140557_version-replace-underscore.js
@@ -1,18 +1,12 @@
-
 exports.up = function(knex) {
-
     return knex.raw(
         `update app_version
         set version = replace(version, '_', '.')
         where version like '%$_%' ESCAPE '$'
-    `)
-};
+    `
+    )
+}
 
 exports.down = function(knex) {
-
-    return knex.raw(
-        `update app_version
-        set version = replace(version, '.', '_')
-        where version like '%$.%' ESCAPE '$'
-    `)
-};
+    return Promise.resolve()
+}

--- a/server/migrations/20200924140557_version-replace-underscore.js
+++ b/server/migrations/20200924140557_version-replace-underscore.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex) {
+
+    return knex.raw(
+        `update app_version
+        set version = replace(version, '_', '.')
+        where version like '%$_%' ESCAPE '$'
+    `)
+};
+
+exports.down = function(knex) {
+
+    return knex.raw(
+        `update app_version
+        set version = replace(version, '.', '_')
+        where version like '%$.%' ESCAPE '$'
+    `)
+};

--- a/server/src/models/v1/in/CreateAppModel.js
+++ b/server/src/models/v1/in/CreateAppModel.js
@@ -17,7 +17,7 @@ const CreateModelAppData = Joi.object().keys({
     }),
     versions: Joi.array().items(
         Joi.object().keys({
-            version: Joi.string(),
+            version: Joi.string().pattern(/_/, { invert: true }),
             minDhisVersion: Joi.string(),
             maxDhisVersion: Joi.string().allow(''),
             demoUrl: Joi.string()

--- a/server/src/models/v1/in/EditAppVersionModel.js
+++ b/server/src/models/v1/in/EditAppVersionModel.js
@@ -5,7 +5,7 @@ const payloadSchema = joi.object({
         .string()
         .uri()
         .allow(''),
-    version: joi.string(),
+    version: joi.string().pattern(/_/, { invert: true }),
     minDhisVersion: joi
         .string()
         .required()

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -57,7 +57,7 @@ const convertAppToV1AppVersion = (app, serverUrl) => {
         created: +new Date(app.version_created_at),
 
         demoUrl: app.demo_url || '',
-        downloadUrl: `${serverUrl}/v1/apps/download/${encodeURIComponent(app.organisation_slug)}/${encodeURIComponent(app.appver_slug)}/${encodeURIComponent(app.version)}.zip`,
+        downloadUrl: `${serverUrl}/v1/apps/download/${encodeURIComponent(app.organisation_slug)}/${encodeURIComponent(app.appver_slug)}_${encodeURIComponent(app.version)}.zip`,
         id: app.version_id,
         lastUpdated: +new Date(app.version_created_at),
         maxDhisVersion: app.max_dhis2_version,

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -57,7 +57,7 @@ const convertAppToV1AppVersion = (app, serverUrl) => {
         created: +new Date(app.version_created_at),
 
         demoUrl: app.demo_url || '',
-        downloadUrl: `${serverUrl}/v1/apps/download/${app.organisation_slug}/${app.appver_slug}_${app.version}.zip`,
+        downloadUrl: `${serverUrl}/v1/apps/download/${encodeURIComponent(app.organisation_slug)}/${encodeURIComponent(app.appver_slug)}/${encodeURIComponent(app.version)}.zip`,
         id: app.version_id,
         lastUpdated: +new Date(app.version_created_at),
         maxDhisVersion: app.max_dhis2_version,

--- a/server/src/routes/v1/apps/handlers/getAppFile.js
+++ b/server/src/routes/v1/apps/handlers/getAppFile.js
@@ -13,7 +13,7 @@ const {
 module.exports = {
     method: 'GET',
     path:
-        '/v1/apps/download/{organisation_slug}/{appver_slug}/{app_version}.zip',
+        '/v1/apps/download/{organisation_slug}/{appver_slug}_{app_version}.zip',
     config: {
         auth: { strategy: 'token', mode: 'try' },
         tags: ['api', 'v1'],

--- a/server/src/routes/v1/apps/handlers/getAppFile.js
+++ b/server/src/routes/v1/apps/handlers/getAppFile.js
@@ -13,7 +13,7 @@ const {
 module.exports = {
     method: 'GET',
     path:
-        '/v1/apps/download/{organisation_slug}/{appver_slug}_{app_version}.zip',
+        '/v1/apps/download/{organisation_slug}/{appver_slug}/{app_version}.zip',
     config: {
         auth: { strategy: 'token', mode: 'try' },
         tags: ['api', 'v1'],


### PR DESCRIPTION
Using `_` in the app-version causes problems as `_` is used to separate the app-slug and the version. Underscores are not encoded by `encodeURIComponent`, so using that will not prevent the invalid URL. 

I've added a migration that replaces all versions with `_` to be replaced with `.`. I've also added validation to the server to prevent versions containing `_`. However we probably should have some more validation to enforce versioning best-practices. Any input on that? We could use `semver` to validate versions, and we do not necessarily need to apply that retroactively. 