### PR TITLE
fix(api): fix apiV2 apiUrl

### DIFF
--- a/client/src/api/utils.js
+++ b/client/src/api/utils.js
@@ -17,10 +17,15 @@ const encodeQueryParameter = param => {
 export const joinUrlPath = (...paths) => {
     const truePaths = paths.filter(path => !!path)
     return truePaths
-        .map(path => {
+        .map((path, i) => {
             path = typeof path === 'string' ? path : String(path)
             //remove trailing and leading slashes
-            return path.replace(/^\/+|\/+$/g, '')
+            let regex = /^\/+|\/+$/g
+            if (i === 0) {
+                // if first path, only remove trailing slash. Leading slash is valid as a relative url to the domain-root.
+                regex = /\/+$/g
+            }
+            return path.replace(regex, '')
         })
         .join('/')
 }


### PR DESCRIPTION
Seems like staging and prod are using `/api/` as the baseUrl, and as we removed both trailing and leading slashes that was treated as a relative url, so apiv2 requests resolved to `/user/api` in some cases. With the leading `/` fetch will resolve to the domain-root. 
