### PR TITLE
fix(dialog): dialog position

### DIFF
--- a/client/src/components/dialog/DialogBase.js
+++ b/client/src/components/dialog/DialogBase.js
@@ -6,7 +6,6 @@ import Dialog from 'material-ui/Dialog'
 import { closeDialog } from '../../actions/actionCreators'
 
 const styles = {
-    bodyStyle: {},
     contentStyle: {
         maxWidth: '500px',
     },
@@ -33,7 +32,9 @@ class DialogBase extends Component {
 
         const finalAction = () => {
             Promise.resolve(approveAction())
-                .then(() => this.props.autoCloseOnApprove && defaultCloseDialog())
+                .then(
+                    () => this.props.autoCloseOnApprove && defaultCloseDialog()
+                )
                 .catch(() => {})
         }
 
@@ -61,14 +62,11 @@ class DialogBase extends Component {
                         actions={actions}
                         modal={false}
                         autoScrollBodyContent
-                        contentStyle={
-                            { ...styles.contentStyle, ...contentStyle } ||
-                            styles.contentStyle
-                        }
-                        bodyStyle={
-                            { ...styles.bodyStyle, ...bodyStyle } ||
-                            styles.bodyStyle
-                        }
+                        contentStyle={{
+                            ...styles.contentStyle,
+                            ...contentStyle,
+                        }}
+                        bodyStyle={{ ...styles.bodyStyle, ...bodyStyle }}
                         onRequestClose={defaultCloseDialog}
                     >
                         <Provider store={ctx.store}>
@@ -82,15 +80,15 @@ class DialogBase extends Component {
 }
 
 DialogBase.propTypes = {
-    title: PropTypes.string,
-    cancelLabel: PropTypes.string,
-    approveLabel: PropTypes.string,
-    cancelAction: PropTypes.func,
     approveAction: PropTypes.func,
-    defaultCloseDialog: PropTypes.func,
-    contentStyle: PropTypes.object,
-    bodyStyle: PropTypes.object,
+    approveLabel: PropTypes.string,
     autoCloseOnApprove: PropTypes.bool,
+    bodyStyle: PropTypes.object,
+    cancelAction: PropTypes.func,
+    cancelLabel: PropTypes.string,
+    contentStyle: PropTypes.object,
+    defaultCloseDialog: PropTypes.func,
+    title: PropTypes.string,
 }
 
 DialogBase.defaultProps = {

--- a/client/src/components/dialog/EditAppVersionDialog.js
+++ b/client/src/components/dialog/EditAppVersionDialog.js
@@ -1,7 +1,6 @@
-// eslint-disable-next-line react/no-deprecated
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
 import { connect } from 'react-redux'
 import DialogBase from './DialogBase'
@@ -39,6 +38,7 @@ export class EditAppVersionDialog extends Component {
                 approveLabel={'Save'}
                 approveAction={this.submitForm.bind(this)}
                 cancelAction={this.props.closeDialog}
+                contentStyle={{ minHeight: '550px' }}
             >
                 <AppVersionForm
                     isNew={false}

--- a/client/src/components/dialog/NewAppVersionDialog.js
+++ b/client/src/components/dialog/NewAppVersionDialog.js
@@ -1,7 +1,6 @@
-// eslint-disable-next-line react/no-deprecated
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
 import { connect } from 'react-redux'
 import DialogBase from './DialogBase'
@@ -40,6 +39,7 @@ export class NewAppVersionDialog extends Component {
                 approveLabel={'Upload'}
                 approveAction={this.submitForm.bind(this)}
                 cancelAction={this.props.closeDialog}
+                contentStyle={{ minHeight: '650px' }}
             >
                 <AppVersionForm
                     isNew={true}

--- a/client/src/components/form/AppVersionForm.jsx
+++ b/client/src/components/form/AppVersionForm.jsx
@@ -1,7 +1,6 @@
-// eslint-disable-next-line react/no-deprecated
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
-import React from 'react';
+import React from 'react'
 
 import { connect } from 'react-redux'
 import * as formUtils from './ReduxFormUtils'
@@ -56,7 +55,7 @@ const AppVersionForm = props => {
     }
 
     //TODO: add error instead of passing false to ErrorOrLoading
-    return channels.loading || channels.error ? (
+    return channels.list.length < 1 && (channels.loading || channels.error) ? (
         <ErrorOrLoading loading={channels.loading} error={channels.error} />
     ) : (
         <Form onSubmit={handleSubmit(onSub)}>


### PR DESCRIPTION
Some of the dialogs has a loading indicator which affects the height of the dialog-content significantly. These dialogs needs a min-height for the Dialog-position calculation to be correct.

Calculation is also improved when loading channels for the second time, as we already have the channels, so we just render these and don't block the UI with a spinner. Channels will probably never change in a session regardless. 