### PR TITLE
feat: apiKey generation

### DIFF
--- a/server/migrations/20210209171106_api-key.js
+++ b/server/migrations/20210209171106_api-key.js
@@ -1,6 +1,6 @@
 exports.up = async function(knex) {
     await knex.schema.createTable('user_api_key', table => {
-        table.string('api_key', 64).primary() // sha256 in hex representation is 64 chars
+        table.string('hashed_api_key', 64).primary() // sha256 in hex representation is 64 chars
 
         table
             .uuid('user_id')

--- a/server/migrations/20210209171106_api-key.js
+++ b/server/migrations/20210209171106_api-key.js
@@ -1,0 +1,24 @@
+exports.up = async function(knex) {
+    await knex.schema.createTable('user_api_key', table => {
+        table.string('api_key', 64).primary() // sha256 in hex representation is 64 chars
+
+        table
+            .uuid('user_id')
+            .notNullable()
+            .unique()
+
+        table
+            .foreign('user_id')
+            .references('id')
+            .inTable('users')
+
+        table
+            .timestamp('created_at', true)
+            .defaultTo(knex.fn.now())
+            .notNullable()
+    })
+}
+
+exports.down = async function(knex) {
+    await knex.schema.dropTable('user_api_key')
+}

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
         "start": "cross-env NODE_ENV=production node ./src/main.js",
         "start:dev": "cross-env DEBUG=knex:tx,apphub* NODE_ENV=development nodemon --watch ./src --inspect src/main.js",
         "test": "cross-env NODE_ENV=test yarn db:reload && lab -a @hapi/code -v --leaks",
+        "test-only": "cross-env NODE_ENV=test lab -a @hapi/code -v --leaks",
         "test:coverage": "cross-env NODE_ENV=test yarn db:reload && lab -c -a @hapi/code -t 80 -r html -o coverage/coverage.html",
         "db:migrate": "knex migrate:latest",
         "db:reset": "knex migrate:rollback && knex migrate:latest",

--- a/server/src/plugins/apiRoutes.js
+++ b/server/src/plugins/apiRoutes.js
@@ -96,6 +96,7 @@ const apiRoutesPlugin = {
 
             //Map required authentication to no-auth
             server.auth.strategy('token', 'no-auth')
+            server.auth.strategy('api-key', 'no-auth')
 
             //Warn with red background
             debug(

--- a/server/src/plugins/apiRoutes.js
+++ b/server/src/plugins/apiRoutes.js
@@ -4,11 +4,15 @@ const Auth0ManagementClient = require('auth0').ManagementClient
 
 const debug = require('debug')('apphub:server:plugins:apiRoutes')
 
-const { createUserValidationFunc, ROLES } = require('../security')
+const {
+    createUserValidationFunc,
+    createApiKeyValidationFunc,
+    ROLES,
+} = require('../security')
 const routes = require('../routes/index.js')
 
 const jwksRsa = require('jwks-rsa')
-
+const { scheme: apiKeyScheme } = require('../security/apiKeyScheme')
 // This is needed to override staticFrontendRoutes's catch-all route
 // so that 404s under /api is not redirected to index.html
 const defaultNotFoundRoute = {
@@ -67,6 +71,11 @@ const apiRoutesPlugin = {
                     authConfig.verifyOptions.audience,
                     auth0ManagementClient
                 ),
+            })
+
+            server.auth.scheme('api-key', apiKeyScheme)
+            server.auth.strategy('api-key', 'api-key', {
+                validate: createApiKeyValidationFunc(knex),
             })
         } else {
             // eslint-disable-next-line no-unused-vars

--- a/server/src/routes/v2/apikey.js
+++ b/server/src/routes/v2/apikey.js
@@ -13,7 +13,7 @@ module.exports = [
             const { db } = h.context
             const { id: userId } = await getCurrentUserFromRequest(request, db)
 
-            const apiKey = ApiKey.createApiKeyForUser(userId, db)
+            const apiKey = await ApiKey.createApiKeyForUser(userId, db)
             return {
                 apiKey,
             }
@@ -32,7 +32,7 @@ module.exports = [
             const { db } = h.context
             const { id: userId } = await getCurrentUserFromRequest(request, db)
 
-            ApiKey.deleteApiKeyForUser(userId, db)
+            await ApiKey.deleteApiKeyForUser(userId, db)
 
             return h.response('API key revoked').code(200)
         },

--- a/server/src/routes/v2/apikey.js
+++ b/server/src/routes/v2/apikey.js
@@ -1,0 +1,45 @@
+const Boom = require('@hapi/boom')
+const Bounce = require('@hapi/bounce')
+const { v4: uuidv4 } = require('uuid')
+const crypto = require('crypto')
+const { wrapError, UniqueViolationError } = require('db-errors')
+const { getCurrentUserFromRequest } = require('../../security')
+module.exports = [
+    {
+        method: 'POST',
+        path: '/v2/key',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id: userId } = await getCurrentUserFromRequest(request, db)
+
+            const apiKey = uuidv4()
+            const hashedHex = crypto
+                .createHash('sha256')
+                .update(apiKey)
+                .digest('hex')
+            console.log(hashedHex)
+            const createKeyTrx = async trx => {
+                try {
+                    await trx('user_api_key').insert({
+                        api_key: hashedHex,
+                        user_id: userId,
+                    })
+                } catch (e) {
+                    const wrapped = wrapError(e)
+                    Bounce.ignore(wrapped, UniqueViolationError)
+                    throw Boom.conflict('Only one API-key per user')
+                }
+            }
+
+            await db.transaction(createKeyTrx)
+            return {
+                apiKey,
+                hashedHex,
+            }
+        },
+    },
+]

--- a/server/src/routes/v2/apikey.js
+++ b/server/src/routes/v2/apikey.js
@@ -3,10 +3,28 @@ const { ApiKey } = require('../../services/')
 
 module.exports = [
     {
+        method: 'GET',
+        path: '/v2/key',
+        config: {
+            auth: 'token',
+            tags: ['api', 'v2'],
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { id: userId } = await getCurrentUserFromRequest(request, db)
+
+            const apiKey = await ApiKey.getApiKeyByUserId(userId, db)
+
+            return {
+                hasApiKey: !!apiKey,
+            }
+        },
+    },
+    {
         method: 'POST',
         path: '/v2/key',
         config: {
-            auth: 'token', // you cannot generate a new token using API-key
+            auth: 'token', // you cannot generate a new key using API-key
             tags: ['api', 'v2'],
         },
         handler: async (request, h) => {

--- a/server/src/routes/v2/index.js
+++ b/server/src/routes/v2/index.js
@@ -3,4 +3,5 @@ module.exports = [
     require('./channels.js'),
     require('./organisations.js'),
     require('./me.js'),
+    require('./apikey.js'),
 ]

--- a/server/src/security/apiKeyScheme.js
+++ b/server/src/security/apiKeyScheme.js
@@ -25,9 +25,10 @@ const scheme = function(server, schemeOptions) {
             if (!apiKey) {
                 return h.unauthenticated(Boom.unauthorized(null, 'api-key'))
             }
-            Joi.attempt(apiKey, options.keySchema)
+
             if (apiKey) {
                 try {
+                    Joi.attempt(apiKey, options.keySchema)
                     const { isValid, credentials } = await options.validate(
                         apiKey,
                         request,

--- a/server/src/security/apiKeyScheme.js
+++ b/server/src/security/apiKeyScheme.js
@@ -1,0 +1,58 @@
+const Boom = require('@hapi/boom')
+const Joi = require('../utils/CustomJoi')
+const debug = require('debug')('apphub:server:security:apiKeyScheme')
+const schemeName = 'api-key'
+
+const optionsSchema = Joi.object({
+    validate: Joi.function().required(),
+    headerKey: Joi.string().default('x-api-key'),
+    keySchema: Joi.object()
+        .schema()
+        .default(
+            Joi.string()
+                .required()
+                .length(36)
+                .message('Invalid API key format')
+        ),
+})
+
+const scheme = function(server, schemeOptions) {
+    const options = Joi.attempt(schemeOptions, optionsSchema)
+    debug('API-key scheme setup')
+    return {
+        authenticate: async (request, h) => {
+            const apiKey = request.headers[options.headerKey]
+            if (!apiKey) {
+                return h.unauthenticated(Boom.unauthorized(null, 'api-key'))
+            }
+            Joi.attempt(apiKey, options.keySchema)
+            if (apiKey) {
+                try {
+                    const { isValid, credentials } = await options.validate(
+                        apiKey,
+                        request,
+                        h
+                    )
+                    if (isValid) {
+                        return h.authenticated({ credentials })
+                    }
+                } catch (e) {
+                    debug('API-key validation failed', e)
+                }
+            }
+
+            return h.unauthenticated(Boom.unauthorized('Invalid API key'))
+        },
+    }
+}
+
+const plugin = {
+    register: function(server, pluginOptions) {
+        server.auth.scheme(schemeName, scheme)
+    },
+}
+
+module.exports = {
+    plugin,
+    scheme,
+}

--- a/server/src/security/createApiKeyValidationFunc.js
+++ b/server/src/security/createApiKeyValidationFunc.js
@@ -1,0 +1,43 @@
+//const { find: findAPIKey } = require('../services/apiKey')
+const Boom = require('@hapi/boom')
+const Bounce = require('@hapi/bounce')
+const debug = require('debug')('apphub:server:security:apiKeyValidation')
+const crypto = require('crypto')
+
+const createApiKeyValidationFunc = db => {
+    return async (apiKey, request, h) => {
+        debug('Validate api-key')
+        const credentials = {}
+        try {
+            const hashedKey = crypto
+                .createHash('sha256')
+                .update(apiKey)
+                .digest('hex')
+
+            const user = await db('users')
+                .select('users.*')
+                .innerJoin('user_api_key', 'user_api_key.user_id', 'users.id')
+                .where({
+                    api_key: hashedKey,
+                })
+                .first()
+
+            if (!user) {
+                throw Boom.unauthorized()
+            }
+            credentials.email = user.email
+            credentials.userId = user.id
+            credentials.roles = []
+
+            return {
+                isValid: true,
+                credentials,
+            }
+        } catch (e) {
+            Bounce.rethrow(e, 'system')
+            return { isValid: false }
+        }
+    }
+}
+
+module.exports = createApiKeyValidationFunc

--- a/server/src/security/createApiKeyValidationFunc.js
+++ b/server/src/security/createApiKeyValidationFunc.js
@@ -41,6 +41,7 @@ const createApiKeyValidationFunc = db => {
             }
         } catch (e) {
             Bounce.rethrow(e, 'system')
+            debug(e)
             return { isValid: false }
         }
     }

--- a/server/src/security/createApiKeyValidationFunc.js
+++ b/server/src/security/createApiKeyValidationFunc.js
@@ -4,7 +4,7 @@ const debug = require('debug')('apphub:server:security:apiKeyValidation')
 const { getUserIdByApiKey } = require('../services/apiKey')
 
 const getUserByApiKey = async (apiKey, trx) => {
-    const userId = getUserIdByApiKey(apiKey, trx)
+    const userId = await getUserIdByApiKey(apiKey, trx)
 
     if (!userId) {
         return null
@@ -24,7 +24,9 @@ const createApiKeyValidationFunc = db => {
         debug('Validate api-key')
         const credentials = {}
         try {
-            const user = db.transaction(trx => getUserByApiKey(apiKey, trx))
+            const user = await db.transaction(trx =>
+                getUserByApiKey(apiKey, trx)
+            )
 
             if (!user) {
                 throw Boom.unauthorized()

--- a/server/src/security/createApiKeyValidationFunc.js
+++ b/server/src/security/createApiKeyValidationFunc.js
@@ -1,4 +1,3 @@
-//const { find: findAPIKey } = require('../services/apiKey')
 const Boom = require('@hapi/boom')
 const Bounce = require('@hapi/bounce')
 const debug = require('debug')('apphub:server:security:apiKeyValidation')

--- a/server/src/security/index.js
+++ b/server/src/security/index.js
@@ -93,6 +93,7 @@ module.exports = {
     canCreateAppVersion,
     canSeeAllApps,
     createUserValidationFunc: require('./createUserValidationFunc'),
+    createApiKeyValidationFunc: require('./createApiKeyValidationFunc'),
     getCurrentUserFromRequest,
     currentUserIsManager,
     ROLES,

--- a/server/src/services/apiKey.js
+++ b/server/src/services/apiKey.js
@@ -24,7 +24,7 @@ const createApiKeyForUser = async (userId, knex) => {
 
     try {
         await knex(userApiKeyTable).insert({
-            api_key: hashedKey,
+            hashed_api_key: hashedKey,
             user_id: userId,
         })
 
@@ -41,7 +41,7 @@ const getUserIdByApiKey = async (apiKey, knex) => {
     const res = await knex(userApiKeyTable)
         .select('user_id')
         .where({
-            api_key: hashedKey,
+            hashed_api_key: hashedKey,
         })
         .first()
 

--- a/server/src/services/apiKey.js
+++ b/server/src/services/apiKey.js
@@ -48,6 +48,15 @@ const getUserIdByApiKey = async (apiKey, knex) => {
     return res && res.user_id
 }
 
+const getApiKeyByUserId = async (userId, knex) => {
+    return knex(userApiKeyTable)
+        .select('hashed_api_key')
+        .where({
+            user_id: userId,
+        })
+        .first()
+}
+
 const deleteApiKeyForUser = async (userId, knex) => {
     const deletedRows = await knex(userApiKeyTable)
         .where({ user_id: userId })
@@ -65,5 +74,6 @@ module.exports = {
     deleteApiKeyForUser,
     generateApiKey,
     getUserIdByApiKey,
+    getApiKeyByUserId,
     hashKey,
 }

--- a/server/src/services/apiKey.js
+++ b/server/src/services/apiKey.js
@@ -1,0 +1,69 @@
+const Boom = require('@hapi/boom')
+const Bounce = require('@hapi/bounce')
+const { v4: uuidv4 } = require('uuid')
+const crypto = require('crypto')
+const { wrapError, UniqueViolationError } = require('db-errors')
+
+const userApiKeyTable = 'user_api_key'
+
+const generateApiKey = () => {
+    const apiKey = uuidv4()
+    const hashedKey = hashKey(apiKey)
+
+    return { apiKey, hashedKey }
+}
+
+const hashKey = apiKey =>
+    crypto
+        .createHash('sha256')
+        .update(apiKey)
+        .digest('hex')
+
+const createApiKeyForUser = async (userId, knex) => {
+    const { apiKey, hashedKey } = generateApiKey()
+
+    try {
+        await knex(userApiKeyTable).insert({
+            api_key: hashedKey,
+            user_id: userId,
+        })
+
+        return apiKey
+    } catch (e) {
+        const wrapped = wrapError(e)
+        Bounce.ignore(wrapped, UniqueViolationError)
+        throw Boom.conflict('Only one API-key per user')
+    }
+}
+
+const getUserIdByApiKey = async (apiKey, knex) => {
+    const hashedKey = hashKey(apiKey)
+    const res = await knex(userApiKeyTable)
+        .select('user_id')
+        .where({
+            api_key: hashedKey,
+        })
+        .first()
+
+    return res && res.user_id
+}
+
+const deleteApiKeyForUser = async (userId, knex) => {
+    const deletedRows = await knex(userApiKeyTable)
+        .where({ user_id: userId })
+        .delete()
+
+    if (deletedRows !== 1) {
+        throw Boom.conflict('User does not have an API key')
+    }
+
+    return deletedRows
+}
+
+module.exports = {
+    createApiKeyForUser,
+    deleteApiKeyForUser,
+    generateApiKey,
+    getUserIdByApiKey,
+    hashKey,
+}

--- a/server/src/services/index.js
+++ b/server/src/services/index.js
@@ -1,3 +1,4 @@
 module.exports = {
     Organisation: require('./organisation'),
+    ApiKey: require('./apiKey'),
 }

--- a/server/test/routes/v2/apiKey.js
+++ b/server/test/routes/v2/apiKey.js
@@ -1,0 +1,105 @@
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const {
+    it,
+    describe,
+    afterEach,
+    beforeEach,
+    before,
+} = (exports.lab = Lab.script())
+
+const knexConfig = require('../../../knexfile')
+const dbInstance = require('knex')(knexConfig)
+const { init } = require('../../../src/server/init-server')
+const { config } = require('../../../src/server/noauth-config')
+const UserMocks = require('../../../seeds/mock/users')
+
+describe('v2/key', () => {
+    let server
+    let db
+
+    before(async () => {
+        config.auth.noAuthUserIdMapping = UserMocks[0].id
+    })
+
+    beforeEach(async () => {
+        db = await dbInstance.transaction()
+
+        server = await init(db, config)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+
+        await db.rollback()
+    })
+
+    describe('create API-key', () => {
+        it('should successfully generate an API-key', async () => {
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/key',
+            }
+
+            const res = await server.inject(opts)
+
+            expect(res.statusCode).to.equal(200)
+
+            const result = res.result
+
+            expect(result).to.be.an.object()
+            expect(result.apiKey).to.be.a.string()
+            expect(result.apiKey).to.have.length(36)
+        })
+
+        it('should return 409 conflict if user already has API-key', async () => {
+            const opts = {
+                method: 'POST',
+                url: '/api/v2/key',
+            }
+
+            const res1 = await server.inject(opts)
+
+            expect(res1.statusCode).to.equal(200)
+
+            const res2 = await server.inject(opts)
+            expect(res2.statusCode).to.equal(409)
+
+            expect(res2.result.message).to.equal('Only one API-key per user')
+        })
+    })
+
+    describe('get API-key status', () => {
+        it('should return object with false if user does not have an API-key', async () => {
+            const opts = {
+                method: 'GET',
+                url: '/api/v2/key',
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(200)
+
+            expect(res.result).to.be.an.object()
+            expect(res.result.hasApiKey).to.equal(false)
+        })
+        it('should return object with true if user does not have an API-key', async () => {
+            const createRes = await server.inject({
+                method: 'POST',
+                url: '/api/v2/key',
+            })
+
+            expect(createRes.statusCode).to.equal(200)
+
+            const opts = {
+                method: 'GET',
+                url: '/api/v2/key',
+            }
+
+            const res = await server.inject(opts)
+            expect(res.statusCode).to.equal(200)
+
+            expect(res.result).to.be.an.object()
+            expect(res.result.hasApiKey).to.equal(true)
+        })
+    })
+})

--- a/server/test/security/apiKeyScheme.js
+++ b/server/test/security/apiKeyScheme.js
@@ -1,0 +1,89 @@
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const {
+    it,
+    describe,
+    afterEach,
+    beforeEach,
+    before,
+} = (exports.lab = Lab.script())
+const Hapi = require('@hapi/hapi')
+const knexConfig = require('../../knexfile')
+const dbInstance = require('knex')(knexConfig)
+const { init } = require('../../src/server/init-server')
+const { config } = require('../../src/server/noauth-config')
+const UserMocks = require('../../seeds/mock/users')
+const { createApiKeyValidationFunc } = require('../../src/security')
+const { scheme: apiKeyScheme } = require('../../src/security/apiKeyScheme')
+
+describe('v2/key', () => {
+    let server
+    let db
+    let protectedServer
+    before(async () => {
+        config.auth.noAuthUserIdMapping = UserMocks[0].id
+    })
+
+    beforeEach(async () => {
+        db = await dbInstance.transaction()
+
+        server = await init(db, config)
+        protectedServer = Hapi.server({ port: 3003 })
+        protectedServer.auth.scheme('api-key', apiKeyScheme)
+        protectedServer.auth.strategy('api-key', 'api-key', {
+            validate: createApiKeyValidationFunc(db),
+        })
+        protectedServer.route({
+            method: 'GET',
+            config: {
+                auth: {
+                    strategies: ['api-key'],
+                },
+            },
+
+            path: '/protectedKey',
+            handler: () => {
+                return 'Success!'
+            },
+        })
+    })
+
+    afterEach(async () => {
+        await server.stop()
+        await protectedServer.stop()
+        await db.rollback()
+    })
+
+    describe('use apiKey', () => {
+        it('should have a protected route that returns 401 - unauthorized', async () => {
+            const res = await protectedServer.inject({
+                method: 'GET',
+                url: '/protectedKey',
+            })
+
+            expect(res.statusCode).to.be.equal(401)
+        })
+
+        it('should accept a valid API-key in header', async () => {
+            const createKeyRes = await server.inject({
+                method: 'POST',
+                url: '/api/v2/key',
+            })
+
+            expect(createKeyRes.statusCode).to.be.equal(200)
+            const apiKey = createKeyRes.result.apiKey
+            expect(apiKey).to.be.a.string()
+            expect(apiKey).to.have.length(36)
+            const res = await protectedServer.inject({
+                method: 'GET',
+                url: '/protectedKey',
+                headers: {
+                    'x-api-key': apiKey,
+                },
+            })
+
+            expect(res.statusCode).to.be.equal(200)
+            expect(res.result).to.be.equal('Success!')
+        })
+    })
+})

--- a/server/test/services/apiKey.js
+++ b/server/test/services/apiKey.js
@@ -1,0 +1,79 @@
+const { expect } = require('@hapi/code')
+
+const Lab = require('@hapi/lab')
+
+const { it, describe, beforeEach, afterEach } = (exports.lab = Lab.script())
+
+const knexConfig = require('../../knexfile')
+const dbInstance = require('knex')(knexConfig)
+
+const UserMocks = require('../../seeds/mock/users')
+
+const ApiKey = require('../../src/services/apiKey')
+
+describe('@services: ApiKey', () => {
+    let db
+    const user = UserMocks[0]
+    beforeEach(async () => {
+        db = await dbInstance.transaction()
+    })
+
+    afterEach(async () => {
+        await db.rollback()
+    })
+
+    describe('generateApiKey', () => {
+        it('should generate a key and a hashedkey', () => {
+            const res = ApiKey.generateApiKey()
+
+            expect(res).to.be.an.object()
+            expect(res.apiKey).to.be.a.string()
+            expect(res.hashedKey).to.be.a.string()
+            expect(res.hashedKey).to.have.length(64)
+            expect(res.apiKey).to.have.length(36)
+        })
+
+        it('should be unique', () => {
+            const res1 = ApiKey.generateApiKey()
+            const res2 = ApiKey.generateApiKey()
+
+            expect(res1).to.not.be.equal(res2)
+            expect(res1.apiKey).to.not.be.equal(res2.apiKey)
+        })
+    })
+
+    describe('hashKey', () => {
+        it('should hash the key to the same hash', () => {
+            const { apiKey, hashedKey } = ApiKey.generateApiKey()
+
+            const hash = ApiKey.hashKey(apiKey)
+
+            expect(hashedKey).to.be.equal(hash)
+        })
+    })
+
+    describe('createApiKeyForUser', () => {
+        it('should successfully generate apiKey for user', async () => {
+            const apiKey = await ApiKey.createApiKeyForUser(user.id, db)
+
+            expect(apiKey).to.be.a.string()
+            expect(apiKey).to.have.length(36)
+        })
+
+        it('should throw error if user already has API-key', async () => {
+            await ApiKey.createApiKeyForUser(user.id, db)
+
+            expect(ApiKey.createApiKeyForUser(user.id, db)).to.reject()
+        })
+    })
+
+    describe('getUserIdByApiKey', () => {
+        it('should get the userId successfully', async () => {
+            const apiKey = await ApiKey.createApiKeyForUser(user.id, db)
+
+            const userId = await ApiKey.getUserIdByApiKey(apiKey, db)
+
+            expect(userId).to.be.equal(user.id)
+        })
+    })
+})

--- a/server/test/services/apiKey.js
+++ b/server/test/services/apiKey.js
@@ -76,4 +76,17 @@ describe('@services: ApiKey', () => {
             expect(userId).to.be.equal(user.id)
         })
     })
+
+    describe('deleteApiKeyForUser', () => {
+        it('should successfully delete an api key', async () => {
+            await ApiKey.createApiKeyForUser(user.id, db)
+
+            const deletedRows = await ApiKey.deleteApiKeyForUser(user.id, db)
+            expect(deletedRows).to.be.equal(1)
+        })
+
+        it('should throw if user does not have API-key', async () => {
+            expect(ApiKey.deleteApiKeyForUser(user.id, db)).to.reject()
+        })
+    })
 })


### PR DESCRIPTION
This implements an API to generate API-keys. The generated API-key can be used instead of an OAuth token to identify the request from the user, provided in the `x-api-key`-header in the request. 

### Implementation 
See https://jira.dhis2.org/projects/HUB/issues/HUB-100 for more information about the considered implementation options. I decided to generate the key using uuid-v4 and hashing this with sha-256. This was the simplest solution; we already have uuid-v4 as a dependency, it's cryptographically secure (backed by [crypto.randomFill](https://nodejs.org/api/crypto.html#crypto_crypto_randomfill_buffer_offset_size_callback)), it's fast and we do not need secrets. However it means that the user cannot see the API-key after first generation. However it's simple to revoke and generate a new one.


Note that this PR does not enable API-keys for all other endpoints. To do that we simply need to add this to the to the route-config. Might look into generating a default for this.

```javascript
 auth: {
    strategies: ['token', 'api-key'],
},
``` 

I've implemented the data as simple as possible, so currently the db table only consists of (api_key, user_id), and the user_id is unique. However, we could potentially support multiple API-keys per user, and have some kind of name or description attached to the key. In that case we should probably have some kind of uuid in that table as well. If this is something we may want down the line it's easier to implement right away. So is this something we should add now?

### Caveats

As mentioned in a comment in the Jira-issue: this does not support roles. That means that a user cannot use the `manager`-permissions to edit other apps other than in their organisation.

