### PR TITLE
fix(version): fix app version upload

### DIFF
--- a/server/src/models/v1/in/CreateAppVersionModel.js
+++ b/server/src/models/v1/in/CreateAppVersionModel.js
@@ -13,7 +13,7 @@ const CreateAppVersionModel = Joi.object().keys({
         .uri()
         .allow('', null),
     images: Joi.array(),
-    channel: Joi.string(),
+    channel: Joi.string().required(),
 })
 
 const payloadSchema = Joi.object({

--- a/server/src/models/v1/in/CreateAppVersionModel.js
+++ b/server/src/models/v1/in/CreateAppVersionModel.js
@@ -7,7 +7,7 @@ const { isSemver } = require('../../helpers')
 
 const CreateAppVersionModel = Joi.object().keys({
     version: Joi.string().custom(isSemver, 'semver validate'),
-    minDhisVersion: Joi.string(),
+    minDhisVersion: Joi.string().required(),
     maxDhisVersion: Joi.string().allow('', null),
     demoUrl: Joi.string()
         .uri()

--- a/server/src/models/v1/in/CreateAppVersionModel.js
+++ b/server/src/models/v1/in/CreateAppVersionModel.js
@@ -6,13 +6,14 @@ const { isSemver } = require('../../helpers')
  */
 
 const CreateAppVersionModel = Joi.object().keys({
-    version: Joi.string().custom(isSemver, 'semver validate'),
+    version: Joi.string()
+        .required()
+        .custom(isSemver, 'semver validate'),
     minDhisVersion: Joi.string().required(),
     maxDhisVersion: Joi.string().allow('', null),
     demoUrl: Joi.string()
         .uri()
         .allow('', null),
-    images: Joi.array(),
     channel: Joi.string().required(),
 })
 

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -26,7 +26,9 @@ module.exports = {
     method: 'POST',
     path: '/v1/apps/{appId}/versions',
     config: {
-        auth: 'token',
+        auth: {
+            strategies: ['token', 'api-key'],
+        },
         tags: ['api', 'v1'],
         payload: {
             maxBytes: 20 * 1024 * 1024, //20MB

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -78,7 +78,7 @@ module.exports = {
         try {
             appVersionJson = JSON.parse(versionPayload)
         } catch (e) {
-            throw Boom.badRequest('Invalid JSON')
+            throw Boom.badRequest(e)
         }
 
         const validationResult = CreateAppVersionModel.def.validate(
@@ -143,7 +143,6 @@ module.exports = {
                         sourceUrl,
                         version,
                     },
-                    db,
                     transaction
                 )
                 versionId = appVersion.id
@@ -162,7 +161,6 @@ module.exports = {
                         name: dbApp.name,
                         languageCode: languageCode,
                     },
-                    db,
                     transaction
                 )
             } catch (err) {
@@ -179,7 +177,6 @@ module.exports = {
                         minDhisVersion,
                         maxDhisVersion,
                     },
-                    db,
                     transaction
                 )
             } catch (err) {


### PR DESCRIPTION
Adds support for uploading app-version with api-key. 

There was a few bugs when testing this due to not actually using the transaction in the helper-function to create the version. This resulted in partially DB-creations. Eg. if you tried to upload with an invalid channel, the version was created in the `app_version`-table, but it failed later when trying to add the version to the channel-table. This resulted in a 500-error if you tried to upload the version again (with fixed channel), even though the version would not show up in the API. 

I intend to merge this using regular merge as the commits are standalone. They are related but does not depend on each other.