### PR TITLE
fix: remove debug lines that spam logs

### DIFF
--- a/server/src/utils/filters.js
+++ b/server/src/utils/filters.js
@@ -13,19 +13,15 @@ const filterAppsBySpecificDhis2Version = (apps, dhis2Version) => {
     const filteredApps = []
 
     const dhis2Semver = semver.coerce(dhis2Version)
-    debug('dhis2Semver', dhis2Semver)
 
     for (let i = 0, n = apps.length; i < n; ++i) {
         const appRow = apps[i]
 
         const maxVersion = semver.coerce(appRow.max_dhis2_version)
-        debug('maxVersion', maxVersion)
 
         const maxVersionValid = semver.valid(maxVersion)
-        debug('maxVersionValid', maxVersionValid)
 
         const minVersion = semver.coerce(appRow.min_dhis2_version)
-        debug('minVersion', minVersion)
 
         if (maxVersionValid) {
             const maxPatch = maxVersion.patch === 0 ? '*' : maxVersion.patch


### PR DESCRIPTION
These lines made it really difficult to read the logs, as it was spammed for each version whenever the a user loaded the index page.

Don' think these give value information anyway, and should've been deleted after implementation.