### PR TITLE
fix: use punycode.toASCII instead of punycode.encode

### DIFF
--- a/server/src/utils/slugify.js
+++ b/server/src/utils/slugify.js
@@ -4,4 +4,4 @@
 const punycode = require('punycode/')
 const slugify = require('slugify')
 
-exports.slugify = string => slugify(punycode.encode(string), { lower: true })
+exports.slugify = string => slugify(punycode.toASCII(string), { lower: true })

--- a/server/src/utils/slugify.js
+++ b/server/src/utils/slugify.js
@@ -4,4 +4,14 @@
 const punycode = require('punycode/')
 const slugify = require('slugify')
 
-exports.slugify = string => slugify(punycode.toASCII(string), { lower: true })
+const slugifyOptions = {
+    lower: true,
+    strict: true,
+}
+
+exports.slugify = string => {
+    const slug = slugify(string, slugifyOptions)
+    return slug.length > 1
+        ? slug
+        : slugify(punycode.toASCII(string), slugifyOptions)
+}

--- a/server/test/data/index.js
+++ b/server/test/data/index.js
@@ -136,7 +136,7 @@ describe('@data::createOrganisation', () => {
         expect(org.id).to.be.a.string()
 
         expect(org.id.length).to.be.equal(36)
-        expect(org.slug).to.equal('xn-test-create-organisation-9ec0a9f3a20b')
+        expect(org.slug).to.equal('test-create-organisation-aaoee')
         expect(org.name).to.equal('Test create organisation åäöèé')
 
         const [shouldExist] = await getOrganisationsByName(org.name, db)

--- a/server/test/data/index.js
+++ b/server/test/data/index.js
@@ -136,7 +136,7 @@ describe('@data::createOrganisation', () => {
         expect(org.id).to.be.a.string()
 
         expect(org.id.length).to.be.equal(36)
-        expect(org.slug).to.equal('test-create-organisation-9ec0a9f3a20b')
+        expect(org.slug).to.equal('xn-test-create-organisation-9ec0a9f3a20b')
         expect(org.name).to.equal('Test create organisation åäöèé')
 
         const [shouldExist] = await getOrganisationsByName(org.name, db)

--- a/server/test/routes/index.js
+++ b/server/test/routes/index.js
@@ -53,7 +53,7 @@ describe('Get all published apps [v1]', async () => {
             'https://play.dhis2.org/2.30/api/apps/Immunization-analysis/index.html#!/report'
         )
         expect(whoApp[0].versions[0].downloadUrl).to.be.equal(
-            'http://localhost:3000/api/v1/apps/download/world-health-organization-/a-nice-app-by-who-_1.0.zip'
+            'http://localhost:3000/api/v1/apps/download/world-health-organization/a-nice-app-by-who_1.0.zip'
         )
 
         expect(whoApp[0].sourceUrl).to.be.equal(
@@ -194,7 +194,7 @@ describe('Get all published apps [v2]', () => {
             'https://play.dhis2.org/2.30/api/apps/Immunization-analysis/index.html#!/report'
         )
         expect(whoApp[0].versions[0].downloadUrl).to.be.equal(
-            'http://localhost:3000/api/v1/apps/download/world-health-organization-/a-nice-app-by-who-_1.0.zip'
+            'http://localhost:3000/api/v1/apps/download/world-health-organization/a-nice-app-by-who_1.0.zip'
         )
 
         expect(whoApp[0].sourceUrl).to.be.equal(


### PR DESCRIPTION
In order to aid decoding, `punycode` appends a hyphen to the end of encoded strings. As we do not need to decode our slugs, using `toASCII` fits our use case better.