### PR TITLE
fix(version-api): use server-package.json for version information

### DIFF
--- a/server/src/routes/v2/version.js
+++ b/server/src/routes/v2/version.js
@@ -1,4 +1,4 @@
-const { version } = require('../../../../package.json')
+const { version } = require('../../../package.json')
 
 module.exports = [
     {


### PR DESCRIPTION
`Dockerfile` does not seem to include the root-workspace `package.json`, so lets use the `server`-one instead.