### PR TITLE
feat: more informative user-facing errors regarding metadata verification

### DIFF
--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -132,13 +132,17 @@ module.exports = {
             )
 
             const { file } = payload
-            verifyBundle({
-                buffer: file._data,
-                appId: app.id,
-                appName: name,
-                version,
-                organisationName: organisation.name,
-            })
+            try {
+                verifyBundle({
+                    buffer: file._data,
+                    appId: app.id,
+                    appName: name,
+                    version,
+                    organisationName: organisation.name,
+                })
+            } catch (error) {
+                throw Boom.badRequest(error)
+            }
             const appUpload = saveFile(
                 `${app.id}/${appVersion.id}`,
                 'app.zip',

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -196,7 +196,12 @@ module.exports = {
                 version,
                 organisationName: organisation.name,
             })
+        } catch (err) {
+            await transaction.rollback()
+            throw Boom.badRequest(err)
+        }
 
+        try {
             await saveFile(`${appId}/${versionId}`, 'app.zip', file._data)
         } catch (err) {
             await transaction.rollback()


### PR DESCRIPTION
If a user attempts to upload a new app with incorrect metadata, they currently encounter the error message 'internal service error' instead of the more informative message provided by `verifyBundle`.