### PR TITLE
fix(verifybundle): ignore name-check for dashboard_widget

### DIFF
--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -14,7 +14,7 @@ const checkManifest = ({ manifest, appId, appName, version, canBeCoreApp }) => {
         throw new Error('Manifest App Hub ID does not match app ID')
     }
     if (manifest.name !== appName) {
-        if (manifest.appType && manifest.appType === 'DASHBOARD_WIDGET') {
+        if (manifest.appType === 'DASHBOARD_WIDGET') {
             // ignore dashboard_widgets, see HUB-123
         } else {
             throw new Error('Manifest name does not match app name')

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -14,7 +14,11 @@ const checkManifest = ({ manifest, appId, appName, version, canBeCoreApp }) => {
         throw new Error('Manifest App Hub ID does not match app ID')
     }
     if (manifest.name !== appName) {
-        throw new Error('Manifest name does not match app name')
+        if (manifest.appType && manifest.appType === 'DASHBOARD_WIDGET') {
+            // ignore dashboard_widgets, see HUB-123
+        } else {
+            throw new Error('Manifest name does not match app name')
+        }
     }
     if (manifest.version !== version) {
         throw new Error('Manifest version does not match app version')


### PR DESCRIPTION
See https://jira.dhis2.org/browse/HUB-123

The check might look a bit weird, but I did not want to introduce a requirement for `manifest.appType`, even though it should be in the manifest. It's either that or a check like `if (manifest.name !== appName) && !manifest.appType || (manifest.appType && manifest.appType !== 'DASHBOARD_WIDGET')`. If you have a better solution please give feedback. 

