### PR TITLE
feat: add coreApp property

### DIFF
--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -5,6 +5,7 @@ import {
     Card,
     Divider,
     Button,
+    Tag,
 } from '@dhis2/ui'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
@@ -17,7 +18,13 @@ import Screenshots from 'src/components/Screenshots/Screenshots'
 import Versions from 'src/components/Versions/Versions'
 import { renderDhisVersionsCompatibility } from 'src/lib/render-dhis-versions-compatibility'
 
-const HeaderSection = ({ appName, appDeveloper, appType, logoSrc }) => (
+const HeaderSection = ({
+    appName,
+    appDeveloper,
+    appType,
+    logoSrc,
+    isCoreApp,
+}) => (
     <section
         className={classnames(styles.appCardSection, styles.appCardHeader)}
     >
@@ -27,6 +34,7 @@ const HeaderSection = ({ appName, appDeveloper, appType, logoSrc }) => (
             <span className={styles.appCardDeveloper}>by {appDeveloper}</span>
             <span className={styles.appCardType}>{appType}</span>
         </div>
+        {isCoreApp && <Tag>Core App</Tag>}
     </section>
 )
 
@@ -34,6 +42,7 @@ HeaderSection.propTypes = {
     appDeveloper: PropTypes.string.isRequired,
     appName: PropTypes.string.isRequired,
     appType: PropTypes.string.isRequired,
+    isCoreApp: PropTypes.bool,
     logoSrc: PropTypes.string,
 }
 
@@ -111,6 +120,7 @@ const AppView = ({ match }) => {
                 appDeveloper={appDeveloper}
                 appType={config.ui.appTypeToDisplayName[app.appType]}
                 logoSrc={logoSrc}
+                isCoreApp={app.coreApp}
             />
             <Divider />
             <AboutSection

--- a/client/src/pages/AppView/AppView.module.css
+++ b/client/src/pages/AppView/AppView.module.css
@@ -18,7 +18,7 @@
 
 .appCardHeader {
     display: grid;
-    grid-template-columns: 72px auto;
+    grid-template-columns: 72px auto 67px;
     grid-gap: var(--spacers-dp12);
 }
 

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
@@ -1,3 +1,4 @@
+import { Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Link } from 'react-router-dom'
@@ -13,7 +14,15 @@ const summarise = text => {
     return text
 }
 
-const AppCardItem = ({ id, name, developer, type, description, images }) => {
+const AppCardItem = ({
+    id,
+    name,
+    developer,
+    type,
+    description,
+    images,
+    isCoreApp,
+}) => {
     const logo = images.find(elem => elem.logo)
 
     return (
@@ -29,6 +38,7 @@ const AppCardItem = ({ id, name, developer, type, description, images }) => {
                         {config.ui.appTypeToDisplayName[type]}
                     </span>
                 </div>
+                {isCoreApp && <Tag>Core App</Tag>}
             </header>
 
             <p className={styles.appCardDescription}>
@@ -48,6 +58,7 @@ AppCardItem.propTypes = {
     type: PropTypes.string.isRequired,
     description: PropTypes.string,
     images: PropTypes.array,
+    isCoreApp: PropTypes.bool,
 }
 
 export default AppCardItem

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.module.css
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.module.css
@@ -17,7 +17,7 @@
 
 .appCardHeader {
     display: grid;
-    grid-template-columns: 72px auto;
+    grid-template-columns: 72px auto 67px;
     grid-gap: var(--spacers-dp12);
 }
 
@@ -49,4 +49,8 @@
     color: var(--colors-grey800);
     font-size: 15px;
     line-height: 21px;
+}
+
+.coreAppIcon {
+    width: 25px
 }

--- a/client/src/pages/Apps/AppCards/AppCards.js
+++ b/client/src/pages/Apps/AppCards/AppCards.js
@@ -39,6 +39,7 @@ const AppCards = ({ isLoading, error, apps }) => {
                     type={app.appType}
                     description={app.description}
                     images={app.images}
+                    isCoreApp={app.coreApp}
                 />
             ))}
         </div>

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -1,4 +1,4 @@
-import { Card, Button, Divider } from '@dhis2/ui'
+import { Card, Button, Divider, Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import { useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
@@ -92,6 +92,7 @@ const DetailsCard = ({ app, mutate }) => {
                     </span>
                     <span className={styles.detailsCardType}>{appType}</span>
                 </div>
+                {app.coreApp && <Tag>Core App</Tag>}
             </section>
             <Divider />
             <section>

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.module.css
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.module.css
@@ -1,6 +1,6 @@
 .detailsCardHeader {
     display: grid;
-    grid-template-columns: 120px auto;
+    grid-template-columns: 120px auto 67px;
     grid-gap: var(--spacers-dp12);
     margin-bottom: var(--spacers-dp8);
 }

--- a/client/src/pages/UserAppEdit/UserAppEdit.js
+++ b/client/src/pages/UserAppEdit/UserAppEdit.js
@@ -7,15 +7,18 @@ import {
     ReactFinalForm,
     InputFieldFF,
     TextAreaFieldFF,
+    SwitchFieldFF,
     hasValue,
     url,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
+import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import styles from './UserAppEdit.module.css'
 import { useQueryV1 } from 'src/api'
 import * as api from 'src/api'
 import { useSuccessAlert, useErrorAlert } from 'src/lib/use-alert'
+import { isManager as isManagerSelector } from 'src/selectors/userSelectors'
 
 const UserAppEdit = ({ match }) => {
     const { appId } = match.params
@@ -23,6 +26,7 @@ const UserAppEdit = ({ match }) => {
     const history = useHistory()
     const successAlert = useSuccessAlert()
     const errorAlert = useErrorAlert()
+    const isManager = useSelector(isManagerSelector)
 
     const handleSubmit = async values => {
         try {
@@ -101,6 +105,18 @@ const UserAppEdit = ({ match }) => {
                             className={styles.field}
                             validate={url}
                         />
+                        {isManager && (
+                            <ReactFinalForm.Field
+                                name="coreApp"
+                                label="Core App"
+                                type="checkbox"
+                                placeholder="e.g. https://github.com/user/app"
+                                helpText="Set the app as an Core app, normally this is set from the manifest when uploading an app."
+                                initialValue={app.coreApp}
+                                component={SwitchFieldFF}
+                                className={styles.field}
+                            />
+                        )}
                         <Button
                             primary
                             type="submit"

--- a/server/migrations/20210705145813_core-app.js
+++ b/server/migrations/20210705145813_core-app.js
@@ -1,0 +1,96 @@
+exports.up = async function (knex) {
+    await knex.schema.table('app', table => {
+        table.boolean('core_app').defaultTo(false)
+    })
+    await knex.raw('DROP VIEW apps_view')
+    // update app-view with column
+    await knex.raw(`
+    CREATE VIEW apps_view AS
+    SELECT  app.id AS app_id,
+            app.type,
+            app.core_app,
+            appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url,
+            media.app_media_id AS media_id, media.original_filename, media.created_at AS media_created_at, media.media_type,
+            localisedapp.language_code, localisedapp.name, localisedapp.description, localisedapp.slug AS appver_slug,
+            s.status, s.created_at AS status_created_at,
+            ac.min_dhis2_version, ac.max_dhis2_version,
+            c.name AS channel_name, c.id AS channel_id,
+            app.contact_email AS contact_email,
+            users.id as owner_id, users.name as owner_name, users.email as owner_email,
+            org.name AS organisation, org.slug AS organisation_slug, org.email as organisation_email
+
+        FROM app
+
+        INNER JOIN app_status AS s
+            ON s.app_id = app.id
+
+        INNER JOIN app_version AS appver
+            ON appver.app_id = s.app_id
+
+        LEFT JOIN app_media_view AS media
+            ON media.app_id = s.app_id
+
+        INNER JOIN app_version_localised AS localisedapp
+            ON localisedapp.app_version_id = appver.id
+
+        INNER JOIN app_channel AS ac
+            ON ac.app_version_id = appver.id
+
+        INNER JOIN channel AS c
+            ON c.id = ac.channel_id
+
+        INNER JOIN users
+            ON users.id = app.created_by_user_id
+
+        INNER JOIN organisation AS org
+            ON org.id = app.organisation_id
+`)
+}
+
+exports.down = async function (knex) {
+    await knex.raw('DROP VIEW apps_view')
+    await knex.schema.table('app', table => {
+        table.dropColumn('core_app')
+    })
+
+    await knex.raw(`
+    CREATE VIEW apps_view AS
+    SELECT  app.id AS app_id,
+          app.type,
+          appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url,
+          media.app_media_id AS media_id, media.original_filename, media.created_at AS media_created_at, media.media_type,
+          localisedapp.language_code, localisedapp.name, localisedapp.description, localisedapp.slug AS appver_slug,
+          s.status, s.created_at AS status_created_at,
+          ac.min_dhis2_version, ac.max_dhis2_version,
+          c.name AS channel_name, c.id AS channel_id,
+          app.contact_email AS contact_email,
+          users.id as owner_id, users.name as owner_name, users.email as owner_email,
+          org.name AS organisation, org.slug AS organisation_slug, org.email as organisation_email
+
+      FROM app
+
+      INNER JOIN app_status AS s
+          ON s.app_id = app.id
+
+      INNER JOIN app_version AS appver
+          ON appver.app_id = s.app_id
+
+      LEFT JOIN app_media_view AS media
+          ON media.app_id = s.app_id
+
+      INNER JOIN app_version_localised AS localisedapp
+          ON localisedapp.app_version_id = appver.id
+
+      INNER JOIN app_channel AS ac
+          ON ac.app_version_id = appver.id
+
+      INNER JOIN channel AS c
+          ON c.id = ac.channel_id
+
+      INNER JOIN users
+          ON users.id = app.created_by_user_id
+
+      INNER JOIN organisation AS org
+          ON org.id = app.organisation_id
+`)
+}

--- a/server/src/data/createApp.js
+++ b/server/src/data/createApp.js
@@ -1,25 +1,18 @@
 const joi = require('@hapi/joi')
-
 const debug = require('debug')('apphub:server:data:createApp')
-
 const { AppTypes } = require('../enums')
 
 const paramsSchema = joi
     .object()
     .keys({
-        userId: joi
-            .string()
-            .uuid()
-            .required(),
+        userId: joi.string().uuid().required(),
         contactEmail: joi.string().email(),
-        orgId: joi
-            .string()
-            .uuid()
-            .required(),
+        orgId: joi.string().uuid().required(),
         appType: joi
             .string()
             .required()
             .valid(...AppTypes),
+        coreApp: joi.bool(),
     })
     .options({ allowUnknown: true })
 
@@ -48,7 +41,7 @@ const createApp = async (params, knex) => {
     }
 
     debug('params: ', params)
-    const { userId, contactEmail, orgId, appType } = params
+    const { userId, contactEmail, orgId, appType, coreApp } = params
 
     //generate a new uuid to insert
 
@@ -60,6 +53,7 @@ const createApp = async (params, knex) => {
                 contact_email: contactEmail,
                 organisation_id: orgId,
                 type: appType,
+                core_app: coreApp,
             })
             .returning('id')
 

--- a/server/src/data/getApps.js
+++ b/server/src/data/getApps.js
@@ -43,10 +43,10 @@ const getApps = (
             }
 
             if (coreApp) {
-                builder.where('organisation', 'DHIS2')
+                builder.where('core_app', true)
             }
             if (coreApp === false) {
-                builder.whereNot('organisation', 'DHIS2')
+                builder.whereNot('core_app', false)
             }
 
             if (query) {

--- a/server/src/data/getApps.js
+++ b/server/src/data/getApps.js
@@ -46,7 +46,7 @@ const getApps = (
                 builder.where('core_app', true)
             }
             if (coreApp === false) {
-                builder.whereNot('core_app', false)
+                builder.where('core_app', false)
             }
 
             if (query) {

--- a/server/src/data/getApps.js
+++ b/server/src/data/getApps.js
@@ -42,11 +42,8 @@ const getApps = (
                 })
             }
 
-            if (coreApp) {
-                builder.where('core_app', true)
-            }
-            if (coreApp === false) {
-                builder.where('core_app', false)
+            if (typeof coreApp === 'boolean') {
+                builder.where('core_app', coreApp)
             }
 
             if (query) {

--- a/server/src/data/updateApp.js
+++ b/server/src/data/updateApp.js
@@ -1,18 +1,12 @@
 const joi = require('@hapi/joi')
-const { slugify } = require('../utils/slugify')
 const { AppTypes } = require('../enums')
+const { slugify } = require('../utils/slugify')
 
 const paramsSchema = joi
     .object()
     .keys({
-        id: joi
-            .string()
-            .uuid()
-            .required(),
-        userId: joi
-            .string()
-            .uuid()
-            .required(),
+        id: joi.string().uuid().required(),
+        userId: joi.string().uuid().required(),
         name: joi.string().max(100),
         description: joi.string().allow(''),
         appType: joi.string().valid(...AppTypes),
@@ -23,10 +17,8 @@ const paramsSchema = joi
             .uri({
                 scheme: ['http', 'https'],
             }),
-        languageCode: joi
-            .string()
-            .max(2)
-            .required(),
+        languageCode: joi.string().max(2).required(),
+        coreApp: joi.bool(),
     })
     .options({ allowUnknown: true })
 
@@ -71,6 +63,7 @@ const updateApp = async (params, knex) => {
         appType,
         description,
         languageCode,
+        coreApp,
     } = params
 
     try {
@@ -85,6 +78,7 @@ const updateApp = async (params, knex) => {
                 type: appType,
                 updated_at: knex.fn.now(),
                 updated_by_user_id: userId,
+                core_app: coreApp,
             })
             .where({
                 id,

--- a/server/src/models/v1/in/CreateAppModel.js
+++ b/server/src/models/v1/in/CreateAppModel.js
@@ -18,6 +18,7 @@ const CreateModelAppData = Joi.object().keys({
         demoUrl: Joi.string().uri().allow(''),
         channel: Joi.string(),
     }),
+    coreApp: Joi.bool(),
 })
 
 const payloadSchema = Joi.object({

--- a/server/src/models/v1/in/EditAppModel.js
+++ b/server/src/models/v1/in/EditAppModel.js
@@ -1,5 +1,4 @@
 const joi = require('@hapi/joi')
-
 const { AppTypes } = require('../../../enums')
 
 const payloadSchema = joi.object({
@@ -13,6 +12,7 @@ const payloadSchema = joi.object({
     }),
     name: joi.string().max(100),
     sourceUrl: joi.string().allow(''),
+    coreApp: joi.bool(),
 })
 
 const EditAppModel = payloadSchema

--- a/server/src/models/v1/out/App.js
+++ b/server/src/models/v1/out/App.js
@@ -1,10 +1,8 @@
 const Joi = require('@hapi/joi')
-
 const { AppStatuses, AppTypes } = require('../../../enums')
-
-const Version = require('./Version')
-const Developer = require('./User')
 const Image = require('./Image')
+const Developer = require('./User')
+const Version = require('./Version')
 
 // v1 api schema
 const def = Joi.object().keys({
@@ -15,40 +13,29 @@ const def = Joi.object().keys({
     created: Joi.number(),
 
     description: Joi.string().allow(''),
+    coreApp: Joi.bool(),
 
     developer: Developer.required(),
 
-    images: Joi.array()
-        .items(Image)
-        .required(),
+    images: Joi.array().items(Image).required(),
 
-    id: Joi.string()
-        .uuid()
-        .required(),
+    id: Joi.string().uuid().required(),
 
     lastUpdated: Joi.number(),
 
-    name: Joi.string()
-        .max(255, 'utf8')
-        .required(),
+    name: Joi.string().max(255, 'utf8').required(),
 
     owner: Joi.string().required(),
 
-    reviews: Joi.array()
-        .items(Joi.any())
-        .required(),
+    reviews: Joi.array().items(Joi.any()).required(),
 
-    sourceUrl: Joi.string()
-        .uri()
-        .allow(''),
+    sourceUrl: Joi.string().uri().allow(''),
 
     status: Joi.string()
         .required()
         .valid(...AppStatuses),
 
-    versions: Joi.array()
-        .items(Version)
-        .min(1),
+    versions: Joi.array().items(Version).min(1),
 })
 
 module.exports = {

--- a/server/src/models/v2/in/CreateAppModel.js
+++ b/server/src/models/v2/in/CreateAppModel.js
@@ -6,6 +6,7 @@ const CreateModelAppData = Joi.object().keys({
     developer: Joi.object().keys({
         organisationId: Joi.string(),
     }),
+    coreApp: Joi.bool(),
 })
 
 const payloadSchema = Joi.object({

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -1,10 +1,8 @@
 const debug = require('debug')(
     'apphub:server:routes:v1:apps:formatting:convertAppsToApiV1Format'
 )
-
-const getServerUrl = require('../../../../utils/getServerUrl')
-
 const { MediaType } = require('../../../../enums')
+const getServerUrl = require('../../../../utils/getServerUrl')
 
 const convertDbAppViewRowToAppApiV1Object = app => ({
     appType: app.type,
@@ -17,7 +15,7 @@ const convertDbAppViewRowToAppApiV1Object = app => ({
 
     name: app.name,
     description: app.description || '',
-
+    coreApp: app.core_app,
     versions: [],
 
     //TODO: set address

--- a/server/src/routes/v1/apps/handlers/editApp.js
+++ b/server/src/routes/v1/apps/handlers/editApp.js
@@ -75,7 +75,7 @@ module.exports = {
                         sourceUrl,
                         appType,
                         languageCode: 'en',
-                        coreApp: isManager ? coreApp : false
+                        coreApp: isManager ? coreApp : undefined
                     },
                     db,
                     transaction

--- a/server/src/routes/v1/apps/handlers/editApp.js
+++ b/server/src/routes/v1/apps/handlers/editApp.js
@@ -52,7 +52,8 @@ module.exports = {
         debug('appsUserCanEdit:', appsUserCanEdit)
         debug('userCanEditApp:', userCanEditApp)
 
-        if (currentUserIsManager(request) || userCanEditApp) {
+        const isManager = currentUserIsManager(request)
+        if (isManager || userCanEditApp) {
             //can edit app
             const transaction = await db.transaction()
 
@@ -62,6 +63,7 @@ module.exports = {
                     description,
                     appType,
                     sourceUrl,
+                    coreApp
                 } = request.payload
 
                 await updateApp(
@@ -73,6 +75,7 @@ module.exports = {
                         sourceUrl,
                         appType,
                         languageCode: 'en',
+                        coreApp: isManager ? coreApp : false
                     },
                     db,
                     transaction

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -10,7 +10,7 @@ const isValidJSON = json => {
 }
 
 const checkManifest = ({ manifest, appId, appName, version, canBeCoreApp }) => {
-    if (manifest.app_hub_id && manifest.app_hub_id !== appId) {
+    if (appId && manifest.app_hub_id && manifest.app_hub_id !== appId) {
         throw new Error('Manifest App Hub ID does not match app ID')
     }
     if (manifest.name !== appName) {
@@ -29,7 +29,7 @@ const checkManifest = ({ manifest, appId, appName, version, canBeCoreApp }) => {
 }
 
 const checkD2Config = ({ d2Config, appId, appName, version, canBeCoreApp }) => {
-    if (d2Config.id && d2Config.id !== appId) {
+    if (appId && d2Config.id && d2Config.id !== appId) {
         throw new Error('D2 config App Hub ID does not match app ID')
     }
     if (d2Config.title !== appName) {
@@ -82,4 +82,9 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
         version,
         canBeCoreApp,
     })
+
+    return {
+        manifest,
+        d2Config
+    }
 }

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -14,7 +14,11 @@ const checkManifest = ({ manifest, appId, appName, version, canBeCoreApp }) => {
         throw new Error('Manifest App Hub ID does not match app ID')
     }
     if (manifest.name !== appName) {
-        throw new Error('Manifest name does not match app name')
+        if (manifest.appType && manifest.appType === 'DASHBOARD_WIDGET') {
+            // ignore dashboard_widgets, see HUB-123
+        } else {
+            throw new Error('Manifest name does not match app name')
+        }
     }
     if (manifest.version !== version) {
         throw new Error('Manifest version does not match app version')

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -65,10 +65,9 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
         version,
         canBeCoreApp,
     })
-
     // D2 config is optional
     if (!entries.includes(d2ConfigPath)) {
-        return
+        return { manifest }
     }
     const d2ConfigJson = zip.readAsText(d2ConfigPath)
     if (!isValidJSON(d2ConfigJson)) {
@@ -85,6 +84,6 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
 
     return {
         manifest,
-        d2Config
+        d2Config,
     }
 }

--- a/server/src/services/app.js
+++ b/server/src/services/app.js
@@ -8,7 +8,14 @@ const {
 } = require('../data')
 
 exports.create = async (
-    { userId: currentUserId, contactEmail, organisationId, appType, status },
+    {
+        userId: currentUserId,
+        contactEmail,
+        organisationId,
+        appType,
+        status,
+        coreApp,
+    },
     db
 ) => {
     const app = await createApp(
@@ -17,6 +24,7 @@ exports.create = async (
             contactEmail,
             orgId: organisationId,
             appType: appType,
+            coreApp,
         },
         db
     )


### PR DESCRIPTION
Adds a property for identifying a core app.

The `core_app`-field is read from the manifest and set if it is true. In that sense this is the first information we are automatically getting from the manifest/d2.config. Note that the uploader must be a manager to be able to set this. 
I've also implemented a simple override for this when editing an application. And you have to be a manager for this property-change to have an effect. 

I'm a bit unsure about how we should show this to users, currently I have a simple tag for this:

![image](https://user-images.githubusercontent.com/13852438/124655018-94a5eb00-de9f-11eb-9a68-4bb728ae01b1.png)
Could potentially have the DHIS2 logo instead? Feedback welcome. 
