### PR TITLE
feat: AppVersion API

### DIFF
--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -7,12 +7,8 @@ const definition = defaultDefinition
         appId: Joi.string(),
         version: Joi.string(),
         channel: Joi.string().required(),
-        demoUrl: Joi.string()
-            .uri()
-            .allow(''),
-        downloadUrl: Joi.string()
-            .uri()
-            .allow(''),
+        demoUrl: Joi.string().uri().allow(''),
+        downloadUrl: Joi.string().uri().allow(''),
         minDhisVersion: Joi.string().required(),
         maxDhisVersion: Joi.string().allow(null, ''),
     })

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -1,0 +1,46 @@
+const Joi = require('../../utils/CustomJoi')
+const { definition: defaultDefinition } = require('./Default')
+const { createDefaultValidator } = require('./helpers')
+
+const definition = defaultDefinition
+    .append({
+        appId: Joi.string(),
+        version: Joi.string(),
+        channel: Joi.string().required(),
+        demoUrl: Joi.string()
+            .uri()
+            .allow(''),
+        downloadUrl: Joi.string()
+            .uri()
+            .allow(''),
+        minDhisVersion: Joi.string().required(),
+        maxDhisVersion: Joi.string().allow(null, ''),
+    })
+    .alter({
+        db: s => s.rename('sourceUrl', 'source_url'),
+    })
+    .rename('source_url', 'sourceUrl')
+    .rename('min_dhis2_version', 'minDhisVersion')
+    .rename('max_dhis2_version', 'maxDhisVersion')
+    .label('AppVersion')
+// .error(errors => new Error('Failed to parse: ' + errors))
+
+const dbDefinition = definition.tailor('db')
+
+// internal -> external
+const externalDefinition = definition.tailor('external')
+
+// database -> internal
+const parseDatabaseJson = createDefaultValidator(definition)
+
+// internal -> database
+const formatDatabaseJson = createDefaultValidator(dbDefinition)
+
+module.exports = {
+    def: definition,
+    definition,
+    dbDefinition,
+    externalDefinition,
+    parseDatabaseJson,
+    formatDatabaseJson,
+}

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -13,7 +13,11 @@ const definition = defaultDefinition
         maxDhisVersion: Joi.string().allow(null, ''),
     })
     .alter({
-        db: s => s.rename('sourceUrl', 'source_url'),
+        db: s =>
+            s
+                .rename('sourceUrl', 'source_url')
+                .rename('minDhisVersion', 'min_dhis2_version')
+                .rename('maxDhisVersion', 'max_dhis2_version'),
     })
     .rename('source_url', 'sourceUrl')
     .rename('min_dhis2_version', 'minDhisVersion')

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -12,18 +12,7 @@ const definition = defaultDefinition
         minDhisVersion: Joi.string().required(),
         maxDhisVersion: Joi.string().allow(null, ''),
     })
-    .alter({
-        db: s =>
-            s
-                .rename('minDhisVersion', 'min_dhis2_version')
-                .rename('maxDhisVersion', 'max_dhis2_version')
-                .rename('demoUrl', 'demo_url'),
-    })
-    .rename('min_dhis2_version', 'minDhisVersion')
-    .rename('max_dhis2_version', 'maxDhisVersion')
-    .rename('demo_url', 'demoUrl')
     .label('AppVersion')
-// .error(errors => new Error('Failed to parse: ' + errors))
 
 const dbDefinition = definition.tailor('db')
 

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -7,7 +7,7 @@ const definition = defaultDefinition
         appId: Joi.string(),
         version: Joi.string(),
         channel: Joi.string().required(),
-        demoUrl: Joi.string().uri().allow(''),
+        demoUrl: Joi.string().uri().allow(null, ''),
         downloadUrl: Joi.string().uri().allow(''),
         minDhisVersion: Joi.string().required(),
         maxDhisVersion: Joi.string().allow(null, ''),
@@ -16,10 +16,12 @@ const definition = defaultDefinition
         db: s =>
             s
                 .rename('minDhisVersion', 'min_dhis2_version')
-                .rename('maxDhisVersion', 'max_dhis2_version'),
+                .rename('maxDhisVersion', 'max_dhis2_version')
+                .rename('demoUrl', 'demo_url'),
     })
     .rename('min_dhis2_version', 'minDhisVersion')
     .rename('max_dhis2_version', 'maxDhisVersion')
+    .rename('demo_url', 'demoUrl')
     .label('AppVersion')
 // .error(errors => new Error('Failed to parse: ' + errors))
 

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -15,11 +15,9 @@ const definition = defaultDefinition
     .alter({
         db: s =>
             s
-                .rename('sourceUrl', 'source_url')
                 .rename('minDhisVersion', 'min_dhis2_version')
                 .rename('maxDhisVersion', 'max_dhis2_version'),
     })
-    .rename('source_url', 'sourceUrl')
     .rename('min_dhis2_version', 'minDhisVersion')
     .rename('max_dhis2_version', 'maxDhisVersion')
     .label('AppVersion')

--- a/server/src/plugins/pagination.js
+++ b/server/src/plugins/pagination.js
@@ -35,14 +35,12 @@ const optionsSchema = Joi.object({
     resultSchema: Joi.object().schema().default(defaultPagingResultSchema),
     keepParams: Joi.bool().default(false),
     decorate: Joi.alternatives()
-
         .try(
             Joi.bool().valid(false),
             Joi.object({
                 slice: Joi.bool(),
             })
         )
-
         .default({ slice: true }),
 })
 

--- a/server/src/plugins/pagination.js
+++ b/server/src/plugins/pagination.js
@@ -1,7 +1,11 @@
 const Boom = require('@hapi/boom')
 const Bounce = require('@hapi/bounce')
+const {
+    Pager,
+    createDefaultPagingResultSchema,
+    defaultPagingQuerySchema,
+} = require('../query/Pager')
 const Joi = require('../utils/CustomJoi')
-const { Pager } = require('../query/Pager')
 
 /**
  * This plugin hooks into onPrehandler, processing all requests it's enabled for.
@@ -22,38 +26,13 @@ const { Pager } = require('../query/Pager')
  * as is.
  */
 
-// Joi-schema for paging props
-// key-names can be changed by using .rename() - but you must renmame
-// to the original keys
-const defaultPagingQuerySchema = Joi.object({
-    paging: Joi.boolean().default(true),
-    page: Joi.number()
-        .default(1)
-        .min(1),
-    pageSize: Joi.number()
-        .default(25)
-        .min(1),
-})
-
-// renames are supported here as well, but you must rename to the original keys
-const defaultPagingResultSchema = Joi.object({
-    pager: Joi.object({
-        page: Joi.number(),
-        pageCount: Joi.number(),
-        pageSize: Joi.number(),
-        total: Joi.number(),
-    }),
-    result: Joi.array(),
-})
+// renames are supported for this schema, but you must rename to the original keys
+const defaultPagingResultSchema = createDefaultPagingResultSchema()
 
 const optionsSchema = Joi.object({
     enabled: Joi.bool().default(false),
-    querySchema: Joi.object()
-        .schema()
-        .default(defaultPagingQuerySchema),
-    resultSchema: Joi.object()
-        .schema()
-        .default(defaultPagingResultSchema),
+    querySchema: Joi.object().schema().default(defaultPagingQuerySchema),
+    resultSchema: Joi.object().schema().default(defaultPagingResultSchema),
     keepParams: Joi.bool().default(false),
     decorate: Joi.alternatives()
 
@@ -67,7 +46,7 @@ const optionsSchema = Joi.object({
         .default({ slice: true }),
 })
 
-const onPreHandler = function(request, h) {
+const onPreHandler = function (request, h) {
     const routeOptions = request.route.settings.plugins.pagination || {}
 
     const options = {
@@ -115,7 +94,7 @@ const onPreHandler = function(request, h) {
  * @returns hapi toolkit.response() with the pager and paginated
  * results.
  */
-const createPaginateDecoration = function(opts) {
+const createPaginateDecoration = function (opts) {
     return function paginate(pager, { result, total }, options = {}) {
         if (!Array.isArray(result)) {
             throw Boom.badImplementation('result must be an array')

--- a/server/src/plugins/queryFilter.js
+++ b/server/src/plugins/queryFilter.js
@@ -37,7 +37,7 @@ const validateDescriptions = {}
 // renameDescriptions is used to rename the filter-Keys to the correct DB-column
 const renameDescriptions = {}
 
-const onPreHandler = function(request, h) {
+const onPreHandler = function (request, h) {
     const routeOptions = request.route.settings.plugins.queryFilter || {}
 
     const options = {
@@ -64,9 +64,8 @@ const onPreHandler = function(request, h) {
 
     if (rename && Joi.isSchema(rename)) {
         if (!renameDescription) {
-            renameDescription = renameDescriptions[
-                request.path
-            ] = rename.describe()
+            renameDescription = renameDescriptions[request.path] =
+                rename.describe()
         }
         renameMap = renameDescription.renames.reduce((acc, curr) => {
             const { from, to } = curr
@@ -77,9 +76,12 @@ const onPreHandler = function(request, h) {
 
     if (Joi.isSchema(routeQueryValidation)) {
         if (!validateDescription) {
-            validateDescription = validateDescriptions[
-                request.path
-            ] = routeQueryValidation.describe()
+            validateDescription = validateDescriptions[request.path] =
+                routeQueryValidation.describe()
+            // if schema has Joi.alternatives(), use first schema-alternative
+            if (validateDescription.matches) {
+                validateDescription = validateDescription.matches[0].schema
+            }
         }
         // only add validations with .filter()
         Object.keys(validateDescription.keys).forEach(k => {

--- a/server/src/plugins/queryFilter.js
+++ b/server/src/plugins/queryFilter.js
@@ -59,12 +59,12 @@ const onPreHandler = function (request, h) {
     const rename = routeOptions.rename
     const queryFilterKeys = new Set()
     let renameMap = rename
-    let validateDescription = validateDescriptions[request.path]
-    let renameDescription = renameDescriptions[request.path]
+    let validateDescription = validateDescriptions[request.route.path]
+    let renameDescription = renameDescriptions[request.route.path]
 
     if (rename && Joi.isSchema(rename)) {
         if (!renameDescription) {
-            renameDescription = renameDescriptions[request.path] =
+            renameDescription = renameDescriptions[request.route.path] =
                 rename.describe()
         }
         renameMap = renameDescription.renames.reduce((acc, curr) => {
@@ -76,12 +76,14 @@ const onPreHandler = function (request, h) {
 
     if (Joi.isSchema(routeQueryValidation)) {
         if (!validateDescription) {
-            validateDescription = validateDescriptions[request.path] =
-                routeQueryValidation.describe()
+            let schemaDescription = routeQueryValidation.describe()
             // if schema has Joi.alternatives(), use first schema-alternative
-            if (validateDescription.matches) {
-                validateDescription = validateDescription.matches[0].schema
+            if (schemaDescription.matches) {
+                schemaDescription = schemaDescription.matches[0].schema
             }
+
+            validateDescription = validateDescriptions[request.route.path] =
+                schemaDescription
         }
         // only add validations with .filter()
         Object.keys(validateDescription.keys).forEach(k => {

--- a/server/src/query/Pager.js
+++ b/server/src/query/Pager.js
@@ -1,17 +1,38 @@
 const Joi = require('../utils/CustomJoi')
 
-const defaultPagingResultSchema = Joi.object({
-    pager: Joi.object({
-        page: Joi.number(),
-        pageCount: Joi.number(),
-        pageSize: Joi.number(),
-        total: Joi.number(),
-    }),
-    result: Joi.array(),
+const createDefaultPagingResultSchema = itemsSchema =>
+    Joi.object({
+        pager: Joi.object({
+            page: Joi.number(),
+            pageCount: Joi.number(),
+            pageSize: Joi.number(),
+            total: Joi.number(),
+        }),
+        result: itemsSchema ? Joi.array().items(itemsSchema) : Joi.array(),
+    })
+
+// Joi-schema for paging props
+// key-names can be changed by using .rename() - but you must renmame
+// to the original keys
+const defaultPagingQuerySchema = Joi.object({
+    paging: Joi.boolean().default(true),
+    page: Joi.number().default(1).min(1),
+    pageSize: Joi.number().default(25).min(1),
 })
 
+const withPagingQuerySchema = joiSchema =>
+    Joi.alternatives().try(
+        defaultPagingQuerySchema.concat(joiSchema),
+        joiSchema
+    )
+const withPagingResultSchema = joiSchema =>
+    Joi.alternatives().try(
+        createDefaultPagingResultSchema(joiSchema),
+        joiSchema
+    )
+
 const defaultOptions = {
-    schema: defaultPagingResultSchema,
+    schema: createDefaultPagingResultSchema(),
 }
 class Pager {
     constructor(pagingParams, options = defaultOptions) {
@@ -64,4 +85,11 @@ class Pager {
     }
 }
 
-module.exports = { default: Pager, Pager }
+module.exports = {
+    default: Pager,
+    Pager,
+    defaultPagingQuerySchema,
+    createDefaultPagingResultSchema,
+    withPagingQuerySchema,
+    withPagingResultSchema,
+}

--- a/server/src/query/executeQuery.js
+++ b/server/src/query/executeQuery.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('apphub:server:executeQuery')
 /**
  * Executes the knex-query, applying filters and paging if present
  *
@@ -22,7 +23,7 @@ async function executeQuery(
         pager.applyToQuery(query)
     }
 
-    // actually run query
+    debug('Executing query: ' + query.toString())
     const rawResult = await query
     let result = rawResult
 

--- a/server/src/routes/v1/apps/handlers/editApp.js
+++ b/server/src/routes/v1/apps/handlers/editApp.js
@@ -58,13 +58,8 @@ module.exports = {
             const transaction = await db.transaction()
 
             try {
-                const {
-                    name,
-                    description,
-                    appType,
-                    sourceUrl,
-                    coreApp
-                } = request.payload
+                const { name, description, appType, sourceUrl, coreApp } =
+                    request.payload
 
                 await updateApp(
                     {
@@ -75,7 +70,7 @@ module.exports = {
                         sourceUrl,
                         appType,
                         languageCode: 'en',
-                        coreApp: isManager ? coreApp : undefined
+                        coreApp: isManager ? coreApp : undefined,
                     },
                     db,
                     transaction

--- a/server/src/routes/v2/appVersions.js
+++ b/server/src/routes/v2/appVersions.js
@@ -41,7 +41,6 @@ module.exports = [
                 },
                 queryFilter: {
                     enabled: true,
-                    rename: AppVersionModel.dbDefinition,
                 },
             },
         },

--- a/server/src/routes/v2/appVersions.js
+++ b/server/src/routes/v2/appVersions.js
@@ -1,0 +1,46 @@
+//const Boom = require('@hapi/boom')
+const Joi = require('@hapi/joi')
+
+// const AppVersionModel = require('../../models/v2/AppVersion')
+// const AppVersionService = require('../../services/appVersion')
+
+module.exports = [
+    {
+        method: 'GET',
+        path: '/v2/apps/{appId}/versions',
+        config: {
+            tags: ['api', 'v2'],
+            response: {
+                // schema: Joi.array().items(AppVersionModel.def),
+            },
+            validate: {
+                params: Joi.object({
+                    appId: Joi.string().required(),
+                }),
+            },
+            plugins: {
+                pagination: {
+                    enabled: true,
+                },
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { appId } = request.params
+            //            const filters = request.plugins.queryFilter
+            const pager = request.plugins.pagination
+            const {
+                appVersion: appVersionMethods,
+            } = request.server.methods.services
+
+            const { value, cached } = await appVersionMethods.findByAppId(
+                appId,
+                { pager },
+                db
+            )
+            const lastModified = cached ? new Date(cached.stored) : new Date()
+
+            return h.response(value).header('Last-modified', lastModified)
+        },
+    },
+]

--- a/server/src/routes/v2/appVersions.js
+++ b/server/src/routes/v2/appVersions.js
@@ -30,6 +30,8 @@ module.exports = [
                         channel: Joi.filter(
                             Joi.stringArray().items(Joi.valid(...CHANNELS))
                         ).description('Filter by channel of the version'),
+                        minDhisVersion: Joi.filter(Joi.string()),
+                        maxDhisVersion: Joi.filter(Joi.string()),
                     })
                 ),
             },
@@ -39,6 +41,7 @@ module.exports = [
                 },
                 queryFilter: {
                     enabled: true,
+                    rename: AppVersionModel.dbDefinition,
                 },
             },
         },

--- a/server/src/routes/v2/appVersions.js
+++ b/server/src/routes/v2/appVersions.js
@@ -1,7 +1,10 @@
 //const Boom = require('@hapi/boom')
+const AppVersionModel = require('../../models/v2/AppVersion')
+const {
+    withPagingResultSchema,
+    withPagingQuerySchema,
+} = require('../../query/Pager')
 const Joi = require('../../utils/CustomJoi')
-
-// const AppVersionModel = require('../../models/v2/AppVersion')
 
 const CHANNELS = ['stable', 'development', 'canary']
 
@@ -12,20 +15,23 @@ module.exports = [
         config: {
             tags: ['api', 'v2'],
             response: {
-                // schema: Joi.array().items(AppVersionModel.def),
+                sample: 0, // schema used for swagger, don't check responses
+                schema: withPagingResultSchema(AppVersionModel.def),
             },
             validate: {
                 params: Joi.object({
                     appId: Joi.string().required(),
                 }),
-                query: Joi.object({
-                    version: Joi.filter(Joi.string()).description(
-                        'Version of the app'
-                    ),
-                    channel: Joi.filter(
-                        Joi.stringArray().items(Joi.valid(...CHANNELS))
-                    ).description('Filter by channel of the version'),
-                }),
+                query: withPagingQuerySchema(
+                    Joi.object({
+                        version: Joi.filter(Joi.string()).description(
+                            'Filter by version of the app'
+                        ),
+                        channel: Joi.filter(
+                            Joi.stringArray().items(Joi.valid(...CHANNELS))
+                        ).description('Filter by channel of the version'),
+                    })
+                ),
             },
             plugins: {
                 pagination: {

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 const Boom = require('@hapi/boom')
+=======
+const { AppStatus } = require('../../enums')
+>>>>>>> feat: add appversion v2 api
 const { getApps } = require('../../data')
 const { AppStatus } = require('../../enums')
 const CreateAppModel = require('../../models/v2/in/CreateAppModel')

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 const Boom = require('@hapi/boom')
-=======
-const { AppStatus } = require('../../enums')
->>>>>>> feat: add appversion v2 api
 const { getApps } = require('../../data')
 const { AppStatus } = require('../../enums')
 const CreateAppModel = require('../../models/v2/in/CreateAppModel')

--- a/server/src/routes/v2/index.js
+++ b/server/src/routes/v2/index.js
@@ -4,5 +4,6 @@ module.exports = [
     require('./organisations.js'),
     require('./me.js'),
     require('./apikey.js'),
-    require('./version.js')
+    require('./version.js'),
+    require('./appVersions'),
 ]

--- a/server/src/server/init-server.js
+++ b/server/src/server/init-server.js
@@ -125,6 +125,7 @@ exports.init = async (knex, config) => {
     await server.register({
         plugin: pagination,
     })
+    server.method(appVersionMethods)
 
     await server.start()
 

--- a/server/src/server/init-server.js
+++ b/server/src/server/init-server.js
@@ -16,6 +16,7 @@ const errorMapper = require('../plugins/errorMapper')
 const queryFilter = require('../plugins/queryFilter')
 const pagination = require('../plugins/pagination')
 const { createEmailService } = require('../services/EmailService')
+const { createAppVersionService } = require('../services/appVersion')
 
 exports.init = async (knex, config) => {
     debug('Starting server...')
@@ -90,6 +91,7 @@ exports.init = async (knex, config) => {
     await server.register(Schmervice)
 
     await server.registerService(createEmailService)
+    await server.registerService(createAppVersionService)
 
     await server.register({
         plugin: staticFrontendRoutes,
@@ -125,7 +127,6 @@ exports.init = async (knex, config) => {
     await server.register({
         plugin: pagination,
     })
-    server.method(appVersionMethods)
 
     await server.start()
 

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -26,6 +26,7 @@ const getAppVersionQuery = knex =>
             knex.ref('ac.min_dhis2_version'),
             knex.ref('ac.max_dhis2_version')
         )
+        .distinct() // app_version_localised may return multiple versions
 
 class AppVersionService extends Schmervice.Service {
     constructor(server, schmerviceOptions) {

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -20,11 +20,11 @@ const getAppVersionQuery = knex =>
             'app_version.version',
             knex.ref('app_version.app_id').as('appId'),
             knex.ref('app_version.created_at').as('createdAt'),
-            knex.ref('app_version.source_url'),
-            knex.ref('app_version.demo_url'),
+            knex.ref('app_version.source_url').as('sourceUrl'),
+            knex.ref('app_version.demo_url').as('demoUrl'),
             knex.ref('channel.name').as('channel'),
-            knex.ref('ac.min_dhis2_version'),
-            knex.ref('ac.max_dhis2_version')
+            knex.ref('ac.min_dhis2_version').as('minDhisVersion'),
+            knex.ref('ac.max_dhis2_version').as('maxDhisVersion')
         )
         .distinct() // app_version_localised may return multiple versions
 

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -45,14 +45,11 @@ class AppVersionService extends Schmervice.Service {
             })
         }
 
-        const res = await executeQuery(query, {
+        return executeQuery(query, {
             filters,
             pager,
             model: AppVersionModel,
         })
-
-        console.log('rez', res)
-        return res
     }
 }
 

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -38,6 +38,7 @@ class AppVersionService extends Schmervice.Service {
             appId
         )
 
+        // needs to be manually applied due to different column-name
         if (filters.getFilter('channel')) {
             filters.applyOneToQuery(query, 'channel', {
                 overrideColumnName: 'channel.name',

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -1,0 +1,59 @@
+const AppVersionModel = require('../models/v2/AppVersion')
+const { executeQuery } = require('../query/executeQuery')
+
+const getAppVersionQuery = knex =>
+    knex('app_version')
+        .innerJoin(
+            knex.ref('app_version_localised').as('avl'),
+            'avl.app_version_id',
+            'app_version.id'
+        )
+        .innerJoin(
+            knex.ref('app_channel').as('ac'),
+            'ac.app_version_id',
+            'app_version.id'
+        )
+        .innerJoin(knex.ref('channel'), 'ac.channel_id', 'channel.id')
+        .select(
+            'app_version.id',
+            'app_version.version',
+            knex.ref('app_version.app_id').as('appId'),
+            knex.ref('app_version.created_at').as('createdAt'),
+            knex.ref('app_version.source_url'),
+            knex.ref('app_version.demo_url'),
+            knex.ref('channel.name').as('channel'),
+            knex.ref('ac.min_dhis2_version'),
+            knex.ref('ac.max_dhis2_version')
+        )
+
+//const find = async ({ filters, pager }, knex) => {}
+
+async function findByAppId(appId, { filters, pager }, knex) {
+    // console.log('thiz2', this)
+    const query = getAppVersionQuery(knex).where('app_version.app_id', appId)
+    return executeQuery(query, { filters, pager, model: AppVersionModel })
+}
+
+const appendNamespace = name => 'services.appVersion.'.concat(name)
+
+// this can be used by hapi server.method for caching
+const methods = [
+    {
+        name: appendNamespace('findByAppId'),
+        method: findByAppId,
+        options: {
+            cache: {
+                //cache: 'appVersion',
+                expiresIn: 10 * 1000,
+                generateTimeout: 2000,
+                getDecoratedValue: true,
+            },
+            generateKey: appId => appId,
+        },
+    },
+]
+
+module.exports = {
+    findByAppId,
+    methods,
+}

--- a/server/src/utils/filterUtils.js
+++ b/server/src/utils/filterUtils.js
@@ -7,6 +7,7 @@ const SEPERATOR_CHAR = ':'
 const stringOperatorsMap = {
     ilike: 'ilike',
     like: 'like',
+    in: 'in',
 }
 
 const operatorMap = {

--- a/server/src/utils/filterUtils.js
+++ b/server/src/utils/filterUtils.js
@@ -21,11 +21,17 @@ const allOperatorsMap = {
     ...stringOperatorsMap,
 }
 
-const toSQLOperator = operatorStr => {
-    const operator = allOperatorsMap[operatorStr]
+const toSQLOperator = (operatorStr, value) => {
+    let operator = allOperatorsMap[operatorStr]
+
+    if (operator === '=' && Array.isArray(value)) {
+        operator = 'in'
+    }
+
     if (!operator) {
         throw new Error('Operator ', operatorStr, ' not supported.')
     }
+
     return operator
 }
 

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -1,0 +1,78 @@
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const { it, describe, afterEach, beforeEach, before } = (exports.lab =
+    Lab.script())
+const knex = require('knex')
+const knexConfig = require('../../../knexfile')
+const appsMocks = require('../../../seeds/mock/apps')
+const appVersions = require('../../../seeds/mock/appversions')
+const users = require('../../../seeds/mock/users')
+const AppVersionModel = require('../../../src/models/v2/AppVersion')
+const { init } = require('../../../src/server/init-server')
+const { config } = require('../../../src/server/noauth-config')
+const Joi = require('../../../src/utils/CustomJoi')
+
+const dbInstance = knex(knexConfig)
+describe('v2/appVersions', () => {
+    let server
+    let db
+
+    before(() => {
+        config.auth.noAuthUserIdMapping = users[0].id
+    })
+
+    beforeEach(async () => {
+        db = await dbInstance.transaction()
+
+        server = await init(db, config)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+
+        await db.rollback()
+    })
+
+    const dhis2App = appsMocks[0]
+    const dhis2AppVersions = appVersions[0]
+
+    describe('get appversions', () => {
+        it('should get version for the app', async () => {
+            const request = {
+                method: 'GET',
+                url: `/api/v2/apps/${dhis2App.id}/versions`,
+            }
+
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(200)
+
+            const result = res.result.result
+
+            const resIds = result.map(r => r.id)
+            expect(resIds).to.include(dhis2AppVersions.map(v => v.id))
+        })
+
+        it('should return a result that complies with AppVersionModel', async () => {
+            const request = {
+                method: 'GET',
+                url: `/api/v2/apps/${dhis2App.id}/versions`,
+            }
+
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(200)
+
+            const result = res.result.result
+
+            Joi.assert(result, Joi.array().items(AppVersionModel.def))
+
+            // check some keys as well
+            result.map(v => {
+                expect(v.appId).to.be.a.string()
+                expect(v.version).to.be.a.string()
+                expect(v.minDhisVersion).to.be.a.string()
+            })
+        })
+    })
+})


### PR DESCRIPTION
Implements an AppVersions API that can be used to paginate and filter versions of an app.
This uses the new architecture, and takes full advantage of the queryFilter-plugin and pagination plugin, as well as the `executeQuery`-abstraction. 

Appversion is implemented as a Schmervice service. This is not strictly necessary as we do not have state or initialization. But I do like the approach, and it makes implementing caching pretty trivial if that is needed down the line. 