### PR TITLE
fix(pagination): separate total count query

### DIFF
--- a/server/src/query/Pager.js
+++ b/server/src/query/Pager.js
@@ -45,8 +45,6 @@ class Pager {
 
     /**
      * Applies limit and offset to the query
-     * Note that this is a simple implementation, and will not work on
-     * eg. distinct queries, as the window function over() does not support distinct.
      * @param {*} query
      */
     applyToQuery(query) {

--- a/server/src/query/Pager.js
+++ b/server/src/query/Pager.js
@@ -108,7 +108,6 @@ class Pager {
     }
 
     sliceAndFormatResult(originalResult) {
-        console.log('slice!')
         const result = this.sliceResult(originalResult)
         return Joi.attempt(
             {

--- a/server/src/query/Pager.js
+++ b/server/src/query/Pager.js
@@ -70,6 +70,21 @@ class Pager {
         return knex.count('* as total_count').from(cloned.as('dt')).first()
     }
 
+    sliceResult(result) {
+        const startIndex = (this.page - 1) * this.pageSize
+        const endIndex = startIndex + this.pageSize
+        return result.slice(startIndex, endIndex)
+    }
+
+    getPagerObject(total) {
+        return {
+            page: this.page,
+            pageSize: this.pageSize,
+            pageCount: Math.ceil(total / this.pageSize),
+            total,
+        }
+    }
+
     enable() {
         this.enabled = true
     }
@@ -83,17 +98,22 @@ class Pager {
             return queryResult
         }
 
-        const pagerObject = {
-            page: this.page,
-            pageSize: this.pageSize,
-            pageCount: Math.ceil(total / this.pageSize),
-            total,
-        }
-
         return Joi.attempt(
             {
-                pager: pagerObject,
+                pager: this.getPagerObject(total),
                 result: queryResult,
+            },
+            this.schema
+        )
+    }
+
+    sliceAndFormatResult(originalResult) {
+        console.log('slice!')
+        const result = this.sliceResult(originalResult)
+        return Joi.attempt(
+            {
+                pager: this.getPagerObject(result.length),
+                result,
             },
             this.schema
         )

--- a/server/src/query/executeQuery.js
+++ b/server/src/query/executeQuery.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('apphub:server:executeQuery')
+
 /**
  * Executes the knex-query, applying filters and paging if present
  *
@@ -30,7 +31,7 @@ async function executeQuery(
 
     if (pager) {
         const countQuery = pager.getTotalCountQuery(query)
-        debug('Executing totalCount-query', countQuery.toString)
+        debug('Executing totalCount-query', countQuery.toString())
         const totalRes = await countQuery
         totalCount = totalRes.total_count
     }

--- a/server/src/query/executeQuery.js
+++ b/server/src/query/executeQuery.js
@@ -26,12 +26,20 @@ async function executeQuery(
     debug('Executing query: ' + query.toString())
     const rawResult = await query
     let result = rawResult
+    let totalCount = result.length
+
+    if (pager) {
+        const countQuery = pager.getTotalCountQuery(query)
+        debug('Executing totalCount-query', countQuery.toString)
+        const totalRes = await countQuery
+        totalCount = totalRes.total_count
+    }
 
     if (options.formatter) {
         result = options.formatter(rawResult)
     } else if (model) {
         // parse if it's a "getter" - ie is a select-query
-        // else we format it do db-format
+        // else we format it to db-format
         if (query._method === 'select') {
             result = model.parseDatabaseJson(result)
         } else {
@@ -40,8 +48,6 @@ async function executeQuery(
     }
 
     if (pager) {
-        const totalCount =
-            rawResult.length > 0 ? rawResult[0].total_count || result.length : 0
         result = pager.formatResult(result, totalCount)
     }
 

--- a/server/test/data/index.js
+++ b/server/test/data/index.js
@@ -180,7 +180,9 @@ describe('@data::createUser', () => {
     })
 })
 
-describe('@data::addUserToOrganisation', () => {
+// this is deprecated, moved to Organisation-service
+// also makes tests not idempotent due to no rollback
+describe.skip('@data::addUserToOrganisation', () => {
     const {
         addUserToOrganisation,
         createOrganisation,

--- a/server/test/query/executeQuery.js
+++ b/server/test/query/executeQuery.js
@@ -207,4 +207,41 @@ describe('executeQuery', () => {
         expect(result.pager).to.exist()
         expect(totalCountQuerySpy.calledWith(organisationQuery)).to.be.true()
     })
+
+    it('should should call sliceAndFormatResult if pager is present and slice is true', async () => {
+        const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
+        const sliceAndFormatResultSpy = sinon.spy(
+            oneItemPager,
+            'sliceAndFormatResult'
+        )
+        const result = await executeQuery(
+            organisationQuery,
+            {
+                pager: oneItemPager,
+            },
+            { slice: true }
+        )
+
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array().length(1)
+        expect(result.pager).to.exist()
+        expect(sliceAndFormatResultSpy.called).to.be.true()
+    })
+
+    it('should should not call applyToQuery if pager is present and slice is true', async () => {
+        const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
+        const applyToQuerySpy = sinon.spy(oneItemPager, 'applyToQuery')
+        const result = await executeQuery(
+            organisationQuery,
+            {
+                pager: oneItemPager,
+            },
+            { slice: true }
+        )
+
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array().length(1)
+        expect(result.pager).to.exist()
+        expect(applyToQuerySpy.called).to.be.false()
+    })
 })

--- a/server/test/query/executeQuery.js
+++ b/server/test/query/executeQuery.js
@@ -1,33 +1,51 @@
-const Lab = require('@hapi/lab')
-const Joi = require('../../src/utils/CustomJoi')
-
-const { it, describe, afterEach } = (exports.lab = Lab.script())
-
 const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const Knex = require('knex')
 const sinon = require('sinon')
+const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
+const knexConfig = require('../../knexfile')
 const appMocks = require('../../seeds/mock/apps')
+const organisationMocks = require('../../seeds/mock/organisations')
 const { executeQuery } = require('../../src/query/executeQuery')
-const { Filters } = require('../../src/utils/Filter')
 const { Pager } = require('../../src/query/Pager')
+const Joi = require('../../src/utils/CustomJoi')
+const { Filters } = require('../../src/utils/Filter')
 
+const dbInstance = Knex(knexConfig)
 describe('executeQuery', () => {
-    afterEach(() => {
+    let db
+
+    beforeEach(async () => {
+        db = await dbInstance.transaction()
+    })
+
+    afterEach(async () => {
         sinon.restore()
+        await db.rollback()
     })
 
     const appMocksWithTotal = appMocks.map(a => ({
         ...a,
         total_count: appMocks.length,
     }))
+
+    const organisationQuery = dbInstance('organisation').select(
+        'organisation.id',
+        'organisation.name',
+        'organisation.email',
+        'organisation.slug',
+        'organisation.created_by_user_id',
+        'organisation.updated_at',
+        'organisation.created_at'
+    )
+
     const getQueryMock = new Promise(resolve => {
         resolve(appMocksWithTotal)
     })
     getQueryMock._method = 'select'
 
-    const insertQueryMock = {
-        then: () => appMocks,
-        _method: 'insert',
-    }
+    const insertQueryMock = new Promise(resolve => resolve(appMocksWithTotal))
+    insertQueryMock._method = 'insert'
 
     const appDefinition = Joi.object({
         id: Joi.string(),
@@ -45,6 +63,8 @@ describe('executeQuery', () => {
         definition: appDefinition,
         parseDatabaseJson: apps =>
             Joi.attempt(apps, Joi.array().items(appDefinition)),
+        formatDatabaseJson: apps =>
+            Joi.attempt(apps, Joi.array().items(appDefinition)),
     }
 
     const filters = Filters.createFromQueryFilters({
@@ -54,9 +74,14 @@ describe('executeQuery', () => {
     const pager = new Pager({ paging: true, pageSize: 25, page: 1 })
 
     it('should execute the query and return result', async () => {
-        const result = await executeQuery(getQueryMock)
+        const result = await executeQuery(organisationQuery)
 
-        expect(result).to.shallow.equal(appMocksWithTotal)
+        expect(result).to.be.an.array().length(organisationMocks.length)
+        result.forEach(org => {
+            expect(
+                organisationMocks.find(o => o.id === org.id)
+            ).to.not.be.undefined()
+        })
     })
 
     it('should execute the query and format it if options.formatter is present', async () => {
@@ -81,6 +106,18 @@ describe('executeQuery', () => {
         expect(result).to.be.an.array()
         expect(
             appModelMock.parseDatabaseJson.calledWith(appMocksWithTotal)
+        ).to.be.true()
+    })
+
+    it('should use formatDatabaseJson if insert query', async () => {
+        sinon.spy(appModelMock, 'formatDatabaseJson')
+        const result = await executeQuery(insertQueryMock, {
+            model: appModelMock,
+        })
+
+        expect(result).to.be.an.array()
+        expect(
+            appModelMock.formatDatabaseJson.calledWith(appMocksWithTotal)
         ).to.be.true()
     })
 
@@ -116,59 +153,58 @@ describe('executeQuery', () => {
         const applyStub = sinon.stub(pager, 'applyToQuery')
         const formatResultStub = sinon
             .stub(pager, 'formatResult')
-            .callsFake((result, len) => result)
-        const result = await executeQuery(getQueryMock, {
+            .callsFake(result => result)
+        const result = await executeQuery(organisationQuery, {
             pager,
         })
 
         expect(result).to.be.an.array()
         expect(applyStub.calledOnce).to.be.true()
-        expect(applyStub.calledWith(getQueryMock)).to.be.true()
-        expect(
-            formatResultStub.calledWith(appMocksWithTotal, appMocks.length)
-        ).to.be.true()
+        expect(applyStub.calledWith(organisationQuery)).to.be.true()
+        expect(formatResultStub.called).to.be.true()
     })
 
     it('should call both pager and filters if both are present', async () => {
         const pagerStub = sinon.stub(pager, 'applyToQuery')
         const formatResultStub = sinon
             .stub(pager, 'formatResult')
-            .callsFake((result, total) => result)
+            .callsFake(result => result)
 
         const filtersStub = sinon.stub(filters, 'applyAllToQuery')
-        const result = await executeQuery(getQueryMock, {
+        const result = await executeQuery(organisationQuery, {
             pager,
             filters,
         })
         expect(result).to.be.an.array()
         expect(filtersStub.calledOnce).to.be.true()
-        expect(filtersStub.calledWith(getQueryMock)).to.be.true()
+        expect(filtersStub.calledWith(organisationQuery)).to.be.true()
 
         expect(pagerStub.calledOnce).to.be.true()
-        expect(pagerStub.calledWith(getQueryMock)).to.be.true()
-        expect(
-            formatResultStub.calledWith(appMocksWithTotal, appMocks.length)
-        ).to.be.true()
+        expect(pagerStub.calledWith(organisationQuery)).to.be.true()
+        expect(formatResultStub.called).to.be.true()
     })
 
-    it('should fallback to result.length if total_count is not present when calling pager.formatResult', async () => {
-        const pagerStub = sinon.stub(pager, 'applyToQuery')
-        const formatResultStub = sinon
-            .stub(pager, 'formatResult')
-            .callsFake((result, len) => result)
-
-        const queryMock = new Promise(resolve => {
-            resolve(appMocks)
-        })
-        const result = await executeQuery(queryMock, {
-            pager,
+    it('should return formatted result', async () => {
+        const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
+        const result = await executeQuery(organisationQuery, {
+            pager: oneItemPager,
         })
 
-        expect(result).to.be.an.array()
-        expect(
-            formatResultStub.calledWith(appMocks, appMocks.length)
-        ).to.be.true()
-        expect(pagerStub.calledOnce).to.be.true()
-        expect(pagerStub.calledWith(queryMock)).to.be.true()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array().length(1)
+        expect(result.pager).to.exist()
+    })
+
+    it('should should call getTotalCountQuery if pager is present', async () => {
+        const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
+        const totalCountQuerySpy = sinon.spy(oneItemPager, 'getTotalCountQuery')
+        const result = await executeQuery(organisationQuery, {
+            pager: oneItemPager,
+        })
+
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array().length(1)
+        expect(result.pager).to.exist()
+        expect(totalCountQuerySpy.calledWith(organisationQuery)).to.be.true()
     })
 })

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -74,5 +74,30 @@ describe('v2/appVersions', () => {
                 expect(v.minDhisVersion).to.be.a.string()
             })
         })
+
+        it('should work with paging params', async () => {
+            const request = {
+                method: 'GET',
+                url: `/api/v2/apps/${dhis2App.id}/versions?pageSize=2`,
+            }
+
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(200)
+
+            const result = res.result
+            const versions = res.result.result
+
+            Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+            expect(result.pager).to.be.an.object()
+            expect(result.pager.pageSize).to.equal(2)
+            expect(versions.length).to.equal(2)
+            // check some keys as well
+            versions.map(v => {
+                expect(v.appId).to.be.a.string()
+                expect(v.version).to.be.a.string()
+                expect(v.minDhisVersion).to.be.a.string()
+            })
+        })
     })
 })


### PR DESCRIPTION
In the first iteration of pagination we used the window function `over()`, to do a somewhat performant and simple way to grab the total number of results in a query (before limit is applied). However this does not support `distinct`, which is needed in a `AppVersion` query. So whenever a `distinct` is used in a query, and whenever there are duplicate tuples, the total will be more than what we actually want.

In this PR I've switched out the window-function with a separate total-count query. In the initial implementation I argued against this due to performance reasons. But due to the constraints above, I've decided to implement it with a separate query, as it's much more flexible (which is how DHIS2 handles `total` as well). There's some performance issues with `total` in DHIS2, but that is with millions of entries and our database is not expected to grow to that level. The queries take single digit `ms` on my machine. 


Another approach would be to rewrite queries to not use distinct, but that complicates these queries. 