### PR TITLE
fix(appversion): add renames for query-filters

### DIFF
--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -12,6 +12,13 @@ const definition = defaultDefinition
         minDhisVersion: Joi.string().required(),
         maxDhisVersion: Joi.string().allow(null, ''),
     })
+    .alter({
+        db: s =>
+            s
+                .rename('minDhisVersion', 'min_dhis2_version')
+                .rename('maxDhisVersion', 'max_dhis2_version')
+                .rename('demoUrl', 'demo_url'),
+    })
     .label('AppVersion')
 
 const dbDefinition = definition.tailor('db')

--- a/server/src/routes/v2/appVersions.js
+++ b/server/src/routes/v2/appVersions.js
@@ -41,6 +41,7 @@ module.exports = [
                 },
                 queryFilter: {
                     enabled: true,
+                    rename: AppVersionModel.dbDefinition,
                 },
             },
         },


### PR DESCRIPTION
I mistakenly did not include the rename-model for the queryFilter. The renames in the sql-query in the service (with `.as()`) is only applied to the results, we also need to rename the query-filter keys to the matching DB-column.
Eg. `minDhisVersion` to `min_dhis2_version`.