### PR TITLE
fix: remove core app tag

### DIFF
--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -5,7 +5,6 @@ import {
     Card,
     Divider,
     Button,
-    Tag,
 } from '@dhis2/ui'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
@@ -18,13 +17,7 @@ import Screenshots from 'src/components/Screenshots/Screenshots'
 import Versions from 'src/components/Versions/Versions'
 import { renderDhisVersionsCompatibility } from 'src/lib/render-dhis-versions-compatibility'
 
-const HeaderSection = ({
-    appName,
-    appDeveloper,
-    appType,
-    logoSrc,
-    isCoreApp,
-}) => (
+const HeaderSection = ({ appName, appDeveloper, appType, logoSrc }) => (
     <section
         className={classnames(styles.appCardSection, styles.appCardHeader)}
     >
@@ -34,7 +27,6 @@ const HeaderSection = ({
             <span className={styles.appCardDeveloper}>by {appDeveloper}</span>
             <span className={styles.appCardType}>{appType}</span>
         </div>
-        {isCoreApp && <Tag>Core App</Tag>}
     </section>
 )
 
@@ -42,7 +34,6 @@ HeaderSection.propTypes = {
     appDeveloper: PropTypes.string.isRequired,
     appName: PropTypes.string.isRequired,
     appType: PropTypes.string.isRequired,
-    isCoreApp: PropTypes.bool,
     logoSrc: PropTypes.string,
 }
 
@@ -120,7 +111,6 @@ const AppView = ({ match }) => {
                 appDeveloper={appDeveloper}
                 appType={config.ui.appTypeToDisplayName[app.appType]}
                 logoSrc={logoSrc}
-                isCoreApp={app.coreApp}
             />
             <Divider />
             <AboutSection

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
@@ -1,4 +1,3 @@
-import { Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Link } from 'react-router-dom'
@@ -14,15 +13,7 @@ const summarise = text => {
     return text
 }
 
-const AppCardItem = ({
-    id,
-    name,
-    developer,
-    type,
-    description,
-    images,
-    isCoreApp,
-}) => {
+const AppCardItem = ({ id, name, developer, type, description, images }) => {
     const logo = images.find(elem => elem.logo)
 
     return (
@@ -38,7 +29,6 @@ const AppCardItem = ({
                         {config.ui.appTypeToDisplayName[type]}
                     </span>
                 </div>
-                {isCoreApp && <Tag>Core App</Tag>}
             </header>
 
             <p className={styles.appCardDescription}>
@@ -58,7 +48,6 @@ AppCardItem.propTypes = {
     type: PropTypes.string.isRequired,
     description: PropTypes.string,
     images: PropTypes.array,
-    isCoreApp: PropTypes.bool,
 }
 
 export default AppCardItem

--- a/client/src/pages/Apps/AppCards/AppCards.js
+++ b/client/src/pages/Apps/AppCards/AppCards.js
@@ -39,7 +39,6 @@ const AppCards = ({ isLoading, error, apps }) => {
                     type={app.appType}
                     description={app.description}
                     images={app.images}
-                    isCoreApp={app.coreApp}
                 />
             ))}
         </div>

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -1,4 +1,4 @@
-import { Card, Button, Divider, Tag } from '@dhis2/ui'
+import { Card, Button, Divider } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import { useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
@@ -92,7 +92,6 @@ const DetailsCard = ({ app, mutate }) => {
                     </span>
                     <span className={styles.detailsCardType}>{appType}</span>
                 </div>
-                {app.coreApp && <Tag>Core App</Tag>}
             </section>
             <Divider />
             <section>


### PR DESCRIPTION
This was added in https://github.com/dhis2/app-hub/pull/522 , but in a recent meeting (Sept 13.) we discussed moving away from the term "core apps" as it's quite ambiguous. Improving upon the organisation feature with a page for organisation should help featuring DHIS2 apps. 
