### PR TITLE
fix(appversion): fix version filtering

### DIFF
--- a/server/seeds/04_appchannel.js
+++ b/server/seeds/04_appchannel.js
@@ -30,12 +30,14 @@ exports.seed = async knex => {
             app_version_id: dhis2AppVersions[0].id,
             channel_id: stableId,
             min_dhis2_version: '2.28',
+            max_dhis2_version: '2.30',
             created_by_user_id: dhis2AppVersions[0].created_by_user_id,
         },
         {
             app_version_id: dhis2AppVersions[1].id,
             channel_id: developmentId,
             min_dhis2_version: '2.29',
+            max_dhis2_version: '2.34',
             created_by_user_id: dhis2AppVersions[1].created_by_user_id,
         },
         {

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -20,6 +20,7 @@ const getAppVersionQuery = knex =>
             'app_version.version',
             knex.ref('app_version.app_id').as('appId'),
             knex.ref('app_version.created_at').as('createdAt'),
+            knex.ref('app_version.updated_at').as('updatedAt'),
             knex.ref('app_version.source_url').as('sourceUrl'),
             knex.ref('app_version.demo_url').as('demoUrl'),
             knex.ref('channel.name').as('channel'),

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -26,7 +26,7 @@ const getAppVersionQuery = knex =>
             knex.ref('ac.min_dhis2_version').as('minDhisVersion'),
             knex.ref('ac.max_dhis2_version').as('maxDhisVersion')
         )
-        .distinct() // app_version_localised may return multiple versions
+        .where('language_code', 'en') // only english is supported for now
 
 class AppVersionService extends Schmervice.Service {
     constructor(server, schmerviceOptions) {
@@ -48,9 +48,13 @@ class AppVersionService extends Schmervice.Service {
 
         // null-values are allowed for maxDhisVersion, so include these if filter is present
         if (filters.getFilter('maxDhisVersion')) {
-            filters.applyOneToQuery(query, 'maxDhisVersion', {
+            filters.applyVersionFilter(query, 'maxDhisVersion', {
                 includeEmpty: true,
             })
+        }
+
+        if (filters.getFilter('minDhisVersion')) {
+            filters.applyVersionFilter(query, 'minDhisVersion')
         }
 
         return executeQuery(query, {

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -49,15 +49,10 @@ class AppVersionService extends Schmervice.Service {
         }
 
         // null-values are allowed for maxDhisVersion, so include these if filter is present
-        if (filters.getFilter('maxDhisVersion')) {
-            filters.applyVersionFilter(query, 'maxDhisVersion', {
-                includeEmpty: true,
-            })
-        }
-
-        if (filters.getFilter('minDhisVersion')) {
-            filters.applyVersionFilter(query, 'minDhisVersion')
-        }
+        filters.applyVersionFilter(query, 'maxDhisVersion', {
+            includeEmpty: true,
+        })
+        filters.applyVersionFilter(query, 'minDhisVersion')
 
         return executeQuery(query, {
             filters,

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -46,6 +46,13 @@ class AppVersionService extends Schmervice.Service {
             })
         }
 
+        // null-values are allowed for maxDhisVersion, so include these if filter is present
+        if (filters.getFilter('maxDhisVersion')) {
+            filters.applyOneToQuery(query, 'maxDhisVersion', {
+                includeEmpty: true,
+            })
+        }
+
         return executeQuery(query, {
             filters,
             pager,

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -27,6 +27,7 @@ const getAppVersionQuery = knex =>
             knex.ref('ac.max_dhis2_version').as('maxDhisVersion')
         )
         .where('language_code', 'en') // only english is supported for now
+        .orderBy('app_version.created_at', 'desc')
 
 class AppVersionService extends Schmervice.Service {
     constructor(server, schmerviceOptions) {

--- a/server/src/utils/Filter.js
+++ b/server/src/utils/Filter.js
@@ -142,6 +142,11 @@ class Filters {
      */
     applyVersionFilter(query, filterName, options = {}) {
         const filter = this.getFilter(filterName)
+
+        if (!filter) {
+            return
+        }
+
         const colName =
             options.overrideColumnName || this.getFilterColumn(filterName)
 

--- a/server/src/utils/Filter.js
+++ b/server/src/utils/Filter.js
@@ -118,15 +118,15 @@ class Filters {
         if (filter) {
             const nameToUse =
                 options.overrideColumnName ||
-                (options.tableName
-                    ? `${options.tableName}.${colName}`
+                (settings.tableName
+                    ? `${settings.tableName}.${colName}`
                     : colName)
             const { value, operator } = filter
 
             query.where(builder => {
                 builder.where(nameToUse, toSQLOperator(operator, value), value)
                 if (settings.includeEmpty) {
-                    builder.orWhereRaw(`nullif(${nameToUse}, ' ') is null`)
+                    builder.orWhereRaw(`nullif( ??, ' ') is null`, nameToUse)
                 }
             })
             this.markApplied(fieldName)

--- a/server/src/utils/Filter.js
+++ b/server/src/utils/Filter.js
@@ -158,9 +158,9 @@ class Filters {
 
         query.where(builder => {
             builder.whereRaw(
-                `string_to_array( ??, '.')::int[] ${toSQLOperator(
+                `string_to_array( regexp_replace(??, '[^0-9.]+', '', 'g'), '.')::int[] ${toSQLOperator(
                     filter.operator
-                )} string_to_array( ?, '.')::int[]`,
+                )} string_to_array( regexp_replace(?, '[^0-9.]+', '', 'g'), '.')::int[]`,
                 [colName, filter.value]
             )
             if (options.includeEmpty) {

--- a/server/src/utils/Filter.js
+++ b/server/src/utils/Filter.js
@@ -140,7 +140,7 @@ class Filters {
      * eg. this will match correctly for for 1.9.0 < 1.10.0,
      * opposed to normal string matching.
      */
-    applyVersionFilter(query, filterName, options) {
+    applyVersionFilter(query, filterName, options = {}) {
         const filter = this.getFilter(filterName)
         const colName =
             options.overrideColumnName || this.getFilterColumn(filterName)

--- a/server/src/utils/filterUtils.js
+++ b/server/src/utils/filterUtils.js
@@ -15,6 +15,7 @@ const operatorMap = {
     lt: '<',
     gt: '>',
     lte: '<=',
+    gte: '>=',
     ne: '<>',
 }
 const allOperatorsMap = {

--- a/server/test/data/index.js
+++ b/server/test/data/index.js
@@ -261,7 +261,7 @@ describe('@data::updateAppVersion', () => {
         )
         expect(app.version_id).to.equal(appVersionIdToUpdate)
         expect(app.version).to.equal('0.1')
-        expect(app.max_dhis2_version).to.equal(null)
+        expect(app.max_dhis2_version).to.equal('2.30')
         expect(app.min_dhis2_version).to.equal('2.28')
         expect(app.demo_url).to.equal(null)
 

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -99,5 +99,128 @@ describe('v2/appVersions', () => {
                 expect(v.minDhisVersion).to.be.a.string()
             })
         })
+
+        describe('with filters', () => {
+            it('should handle channel filter', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?channel=development`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                const versions = res.result.result
+
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                expect(result.pager).to.be.an.object()
+                // check some keys as well
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    expect(v.channel).to.be.equal('development')
+                })
+            })
+
+            it('should handle minDhisVersion', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?minDhisVersion=eq:2.29`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                console.log(result)
+                const versions = result.result
+
+                console.log(versions)
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    expect(v.minDhisVersion).to.be.equal('2.29')
+                })
+            })
+
+            it('should handle minDhisVersion with lte and gte', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?minDhisVersion=lte:2.28`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                const versions = result.result
+
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    expect(v.minDhisVersion).to.be.below('2.29')
+                })
+            })
+
+            it('should handle maxDhisVersion', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?maxDhisVersion=lte:2.34`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                const versions = result.result
+
+                expect(versions.length).to.be.above(0)
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    if (v.maxDhisVersion) {
+                        const [, major] = v.maxDhisVersion
+                            .split('.')
+                            .map(Number)
+                        expect(major).to.be.lessThan(35)
+                    }
+                })
+            })
+
+            it('should handle both minDhisVersion and maxDhisVersion', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?maxDhisVersion=lte:2.34&minDhisVersion=gte:2.29`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                const versions = result.result
+
+                expect(versions.length).to.be.above(0)
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    if (v.maxDhisVersion) {
+                        const [, major] = v.maxDhisVersion
+                            .split('.')
+                            .map(Number)
+                        expect(major).to.be.between(28, 35)
+                    }
+                })
+            })
+        })
     })
 })

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -221,6 +221,33 @@ describe('v2/appVersions', () => {
                     }
                 })
             })
+
+            it('should not fail when version include valid semver characters', async () => {
+                const request = {
+                    method: 'GET',
+                    url: `/api/v2/apps/${dhis2App.id}/versions?maxDhisVersion=lte:2.34-beta&minDhisVersion=gte:2.29-alpha`,
+                }
+
+                const res = await server.inject(request)
+
+                expect(res.statusCode).to.equal(200)
+
+                const result = res.result
+                const versions = result.result
+
+                expect(versions.length).to.be.above(0)
+                Joi.assert(versions, Joi.array().items(AppVersionModel.def))
+                versions.forEach(v => {
+                    expect(v.appId).to.be.a.string()
+                    expect(v.version).to.be.a.string()
+                    if (v.maxDhisVersion) {
+                        const [, major] = v.maxDhisVersion
+                            .split('.')
+                            .map(Number)
+                        expect(major).to.be.between(28, 35)
+                    }
+                })
+            })
         })
     })
 })


### PR DESCRIPTION
We allow null and empty strings for `maxDhisVersion`, and the previous filtering implementation would just do a naive `where`, so it would not return any results.

This implements a generic way to include "empty" results for a filter through an option `includeEmpty` to `applyOneToQuery`. Empty is defined as `null`, the empty string `''` or a string with just spaces.

Implements a simple way to compare version numbers in SQL. Note that this is not fully `semver` compatible, as it only supports simple  version-numbers (no prelease, beta, etc), however that should be fine for now as we only use it for DHIS core version. There is a [semver postgres-plugin](https://pgxn.org/dist/semver/), but that is more work to implement. 

Also includes `gte` (greater or equal) to the list of allowed operators for filtering.