### PR TITLE
feat(apps): availableChannels API

### DIFF
--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -175,9 +175,8 @@ module.exports = [
             const { appVersionService } = request.services(true)
 
             const { appId } = request.params
-            const channels = appVersionService.getAvailableChannels(appId, db)
 
-            return channels
+            return appVersionService.getAvailableChannels(appId, db)
         },
     },
 ]

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -114,9 +114,8 @@ module.exports = [
 
             const { payload } = request
             const appJsonPayload = JSON.parse(payload.app)
-            const appJsonValidationResult = CreateAppModel.def.validate(
-                appJsonPayload
-            )
+            const appJsonValidationResult =
+                CreateAppModel.def.validate(appJsonPayload)
 
             if (appJsonValidationResult.error) {
                 throw Boom.badRequest(appJsonValidationResult.error)
@@ -157,6 +156,28 @@ module.exports = [
             )
 
             return h.response(app).created(`/v2/apps/${app.id}`)
+        },
+    },
+    {
+        method: 'GET',
+        path: '/v2/apps/{appId}/channels',
+        config: {
+            auth: false,
+            tags: ['api', 'v2'],
+            validate: {
+                params: Joi.object({
+                    appId: Joi.string().required(),
+                }),
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { appVersionService } = request.services(true)
+
+            const { appId } = request.params
+            const channels = appVersionService.getAvailableChannels(appId, db)
+
+            return channels
         },
     },
 ]

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -60,6 +60,19 @@ class AppVersionService extends Schmervice.Service {
             model: AppVersionModel,
         })
     }
+
+    async getAvailableChannels(appId, knex) {
+        const query = getAppVersionQuery(knex)
+            .clear('select')
+            .clear('order')
+            .select('channel.name')
+            .where('app_version.app_id', appId)
+            .distinct()
+
+        const result = await executeQuery(query)
+
+        return result.map(c => c.name)
+    }
 }
 
 const createAppVersionService = (server, schmerviceOptions) => {

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -13,6 +13,7 @@ const { config } = require('../../../src/server/noauth-config')
 const Joi = require('../../../src/utils/CustomJoi')
 
 const dbInstance = knex(knexConfig)
+
 describe('v2/appVersions', () => {
     let server
     let db
@@ -248,6 +249,41 @@ describe('v2/appVersions', () => {
                     }
                 })
             })
+        })
+    })
+
+    describe('getAvailableChannels', () => {
+        it('should only return channels that have versions published', async () => {
+            const canaryOnlyApp = appsMocks[5]
+            const request = {
+                method: 'GET',
+                url: `/api/v2/apps/${canaryOnlyApp.id}/channels`,
+            }
+
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(200)
+            const result = res.result
+            expect(result).to.be.an.array()
+            expect(result[0]).to.be.equal('canary')
+        })
+
+        it('should return unique channels', async () => {
+            const request = {
+                method: 'GET',
+                url: `/api/v2/apps/${dhis2App.id}/channels`,
+            }
+
+            const res = await server.inject(request)
+
+            expect(res.statusCode).to.equal(200)
+            const result = res.result
+
+            expect(result).to.be.an.array().length(3)
+            expect(result).to.include('stable')
+
+            const unique = [...new Set(result)]
+            expect(unique.length).to.equal(result.length)
         })
     })
 })

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -251,39 +251,4 @@ describe('v2/appVersions', () => {
             })
         })
     })
-
-    describe('getAvailableChannels', () => {
-        it('should only return channels that have versions published', async () => {
-            const canaryOnlyApp = appsMocks[5]
-            const request = {
-                method: 'GET',
-                url: `/api/v2/apps/${canaryOnlyApp.id}/channels`,
-            }
-
-            const res = await server.inject(request)
-
-            expect(res.statusCode).to.equal(200)
-            const result = res.result
-            expect(result).to.be.an.array()
-            expect(result[0]).to.be.equal('canary')
-        })
-
-        it('should return unique channels', async () => {
-            const request = {
-                method: 'GET',
-                url: `/api/v2/apps/${dhis2App.id}/channels`,
-            }
-
-            const res = await server.inject(request)
-
-            expect(res.statusCode).to.equal(200)
-            const result = res.result
-
-            expect(result).to.be.an.array().length(3)
-            expect(result).to.include('stable')
-
-            const unique = [...new Set(result)]
-            expect(unique.length).to.equal(result.length)
-        })
-    })
 })


### PR DESCRIPTION
Adds a simple API-endpoint that fetches all channels that have a published version for a particular app.

The purpose for this API is for the client to know which 'channel'-filters to show, as we want to hide channels that are not relevant for that app. This was previously done on the client side, but this endpoint is needed to support this feature when we are moving to paginated responses (#555 ).


`/v2/apps/APPID/channels`
