### PR TITLE
feat: configurable total-results strategy

### DIFF
--- a/server/src/query/Pager.js
+++ b/server/src/query/Pager.js
@@ -47,11 +47,17 @@ class Pager {
      * Applies limit and offset to the query
      * @param {*} query
      */
-    applyToQuery(query) {
+    applyToQuery(query, includeTotal) {
         if (!this.enabled) {
             return
         }
         const offset = (this.page - 1) * this.pageSize
+
+        if (includeTotal) {
+            const knex = query.client
+            query.select(knex.raw('count(*) over() as total_count'))
+        }
+
         query.limit(this.pageSize)
         query.offset(offset)
     }

--- a/server/src/query/executeQuery.js
+++ b/server/src/query/executeQuery.js
@@ -1,5 +1,15 @@
 const debug = require('debug')('apphub:server:executeQuery')
 
+const pagingStrategies = {
+    WINDOW: 'window',
+    SEPARATE: 'separate',
+    SLICE: 'slice',
+}
+
+const defaultOptions = {
+    pagingStrategy: pagingStrategies.WINDOW,
+}
+
 /**
  * Executes the knex-query, applying filters and paging if present
  *
@@ -10,19 +20,32 @@ const debug = require('debug')('apphub:server:executeQuery')
  * @param {*} queryHelpers.model a "model" object that can be used to format the output.
  * @param {*} options Options object
  * @param {*} options.formatter a function with signature `function(result)` that overrides format-logic from model, should return formatted result
- * @param {Boolean} options.slice if true and pager is present, the result will be sliced in memory, without using a second SQL-query.
+ * @param {string} options.pagingStrategy the strategy to use for pagination of the query.
+ *  Valid options:
+ *
+ *    `window`: Default. A window-function (count() over() ) is used to get the total of the query together with the results.
+ *     This does not work with eg. `distinct` selects.
+ *
+ *    `separate`: a separate query will be executed to get the total of the query.
+ *
+ *    `slice`: the SQL query will return all rows and be sliced in memory according to pager-obect,
+ *
+ * Note that this only has an effect if `pager` is present.
  * */
 async function executeQuery(
     query,
     { filters, pager, model } = {},
-    options = {}
+    options = defaultOptions
 ) {
     if (filters) {
         filters.applyAllToQuery(query)
     }
 
-    if (pager && !options.slice) {
-        pager.applyToQuery(query)
+    if (pager && options.pagingStrategy !== pagingStrategies.SLICE) {
+        pager.applyToQuery(
+            query,
+            options.pagingStrategy === pagingStrategies.WINDOW
+        )
     }
 
     debug('Executing query: ' + query.toString())
@@ -42,7 +65,7 @@ async function executeQuery(
     }
 
     if (pager) {
-        if (options.slice) {
+        if (options.pagingStrategy === pagingStrategies.SLICE) {
             result = pager.sliceAndFormatResult(result)
         } else {
             const countQuery = pager.getTotalCountQuery(query)
@@ -58,4 +81,5 @@ async function executeQuery(
 
 module.exports = {
     executeQuery,
+    pagingStrategies,
 }

--- a/server/src/query/executeQuery.js
+++ b/server/src/query/executeQuery.js
@@ -74,6 +74,11 @@ async function executeQuery(
             const totalCount = totalRes.total_count
             result = pager.formatResult(result, totalCount)
         }
+    } else {
+        // keep same API if no pager
+        result = {
+            result,
+        }
     }
 
     return result

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -69,7 +69,7 @@ class AppVersionService extends Schmervice.Service {
             .where('app_version.app_id', appId)
             .distinct()
 
-        const result = await executeQuery(query)
+        const { result } = await executeQuery(query)
 
         return result.map(c => c.name)
     }

--- a/server/test/query/executeQuery.js
+++ b/server/test/query/executeQuery.js
@@ -79,8 +79,9 @@ describe('executeQuery', () => {
     it('should execute the query and return result', async () => {
         const result = await executeQuery(organisationQuery)
 
-        expect(result).to.be.an.array().length(organisationMocks.length)
-        result.forEach(org => {
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array().length(organisationMocks.length)
+        result.result.forEach(org => {
             expect(
                 organisationMocks.find(o => o.id === org.id)
             ).to.not.be.undefined()
@@ -94,9 +95,10 @@ describe('executeQuery', () => {
             formatter: formatterSpy,
         })
 
-        expect(result).to.not.shallow.equal(appMocksWithTotal)
+        expect(result).to.be.an.object()
+        expect(result.result).to.not.shallow.equal(appMocksWithTotal)
         expect(formatterSpy.calledOnce).to.be.true()
-        result.forEach(a => {
+        result.result.forEach(a => {
             expect(a).to.not.be.an.object()
             expect(a).to.be.a.string()
         })
@@ -106,7 +108,8 @@ describe('executeQuery', () => {
         sinon.spy(appModelMock, 'parseDatabaseJson')
         const result = await executeQuery(getQueryMock, { model: appModelMock })
 
-        expect(result).to.be.an.array()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array()
         expect(
             appModelMock.parseDatabaseJson.calledWith(appMocksWithTotal)
         ).to.be.true()
@@ -118,7 +121,8 @@ describe('executeQuery', () => {
             model: appModelMock,
         })
 
-        expect(result).to.be.an.array()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array()
         expect(
             appModelMock.formatDatabaseJson.calledWith(appMocksWithTotal)
         ).to.be.true()
@@ -136,7 +140,8 @@ describe('executeQuery', () => {
             }
         )
 
-        expect(result).to.not.shallow.equal(appMocksWithTotal)
+        expect(result).to.be.an.object()
+        expect(result.result).to.not.shallow.equal(appMocksWithTotal)
         expect(formatterSpy.calledWith(appMocksWithTotal)).to.be.true()
         expect(appModelMock.parseDatabaseJson.notCalled).to.be.true()
     })
@@ -147,44 +152,45 @@ describe('executeQuery', () => {
             filters,
         })
 
-        expect(result).to.be.an.array()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array()
         expect(funcStub.calledOnce).to.be.true()
         expect(funcStub.calledWith(getQueryMock)).to.be.true()
     })
 
     it('should call pager.applyToQuery and pager.formatResult if pager is present', async () => {
         const applyStub = sinon.stub(pager, 'applyToQuery')
-        const formatResultStub = sinon
-            .stub(pager, 'formatResult')
-            .callsFake(result => result)
+        const formatResultSpy = sinon.spy(pager, 'formatResult')
+
         const result = await executeQuery(organisationQuery, {
             pager,
         })
 
-        expect(result).to.be.an.array()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array()
         expect(applyStub.calledOnce).to.be.true()
         expect(applyStub.calledWith(organisationQuery, true)).to.be.true()
-        expect(formatResultStub.called).to.be.true()
+        expect(formatResultSpy.called).to.be.true()
     })
 
     it('should call both pager and filters if both are present', async () => {
         const pagerStub = sinon.stub(pager, 'applyToQuery')
-        const formatResultStub = sinon
-            .stub(pager, 'formatResult')
-            .callsFake(result => result)
+
+        const formatResultSpy = sinon.spy(pager, 'formatResult')
 
         const filtersStub = sinon.stub(filters, 'applyAllToQuery')
         const result = await executeQuery(organisationQuery, {
             pager,
             filters,
         })
-        expect(result).to.be.an.array()
+        expect(result).to.be.an.object()
+        expect(result.result).to.be.an.array()
         expect(filtersStub.calledOnce).to.be.true()
         expect(filtersStub.calledWith(organisationQuery)).to.be.true()
 
         expect(pagerStub.calledOnce).to.be.true()
         expect(pagerStub.calledWith(organisationQuery, true)).to.be.true()
-        expect(formatResultStub.called).to.be.true()
+        expect(formatResultSpy.called).to.be.true()
     })
 
     it('should return formatted result', async () => {

--- a/server/test/query/executeQuery.js
+++ b/server/test/query/executeQuery.js
@@ -6,7 +6,10 @@ const { it, describe, afterEach, beforeEach } = (exports.lab = Lab.script())
 const knexConfig = require('../../knexfile')
 const appMocks = require('../../seeds/mock/apps')
 const organisationMocks = require('../../seeds/mock/organisations')
-const { executeQuery } = require('../../src/query/executeQuery')
+const {
+    executeQuery,
+    pagingStrategies,
+} = require('../../src/query/executeQuery')
 const { Pager } = require('../../src/query/Pager')
 const Joi = require('../../src/utils/CustomJoi')
 const { Filters } = require('../../src/utils/Filter')
@@ -160,7 +163,7 @@ describe('executeQuery', () => {
 
         expect(result).to.be.an.array()
         expect(applyStub.calledOnce).to.be.true()
-        expect(applyStub.calledWith(organisationQuery)).to.be.true()
+        expect(applyStub.calledWith(organisationQuery, true)).to.be.true()
         expect(formatResultStub.called).to.be.true()
     })
 
@@ -180,7 +183,7 @@ describe('executeQuery', () => {
         expect(filtersStub.calledWith(organisationQuery)).to.be.true()
 
         expect(pagerStub.calledOnce).to.be.true()
-        expect(pagerStub.calledWith(organisationQuery)).to.be.true()
+        expect(pagerStub.calledWith(organisationQuery, true)).to.be.true()
         expect(formatResultStub.called).to.be.true()
     })
 
@@ -195,11 +198,12 @@ describe('executeQuery', () => {
         expect(result.pager).to.exist()
     })
 
-    it('should should call getTotalCountQuery if pager is present', async () => {
+    it('should call getTotalCountQuery if pager is present and pagingStrategy is "separate"', async () => {
         const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
         const totalCountQuerySpy = sinon.spy(oneItemPager, 'getTotalCountQuery')
         const result = await executeQuery(organisationQuery, {
             pager: oneItemPager,
+            pagingStrategy: pagingStrategies.SEPARATE,
         })
 
         expect(result).to.be.an.object()
@@ -208,7 +212,7 @@ describe('executeQuery', () => {
         expect(totalCountQuerySpy.calledWith(organisationQuery)).to.be.true()
     })
 
-    it('should should call sliceAndFormatResult if pager is present and slice is true', async () => {
+    it('should call sliceAndFormatResult if pager is present and pagingStrategy is "slice"', async () => {
         const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
         const sliceAndFormatResultSpy = sinon.spy(
             oneItemPager,
@@ -219,7 +223,7 @@ describe('executeQuery', () => {
             {
                 pager: oneItemPager,
             },
-            { slice: true }
+            { pagingStrategy: 'slice' }
         )
 
         expect(result).to.be.an.object()
@@ -228,7 +232,7 @@ describe('executeQuery', () => {
         expect(sliceAndFormatResultSpy.called).to.be.true()
     })
 
-    it('should should not call applyToQuery if pager is present and slice is true', async () => {
+    it('should not call applyToQuery if pager is present and pagingStrategy is "slice"', async () => {
         const oneItemPager = new Pager({ paging: true, pageSize: 1, page: 1 })
         const applyToQuerySpy = sinon.spy(oneItemPager, 'applyToQuery')
         const result = await executeQuery(
@@ -236,7 +240,7 @@ describe('executeQuery', () => {
             {
                 pager: oneItemPager,
             },
-            { slice: true }
+            { pagingStrategy: 'slice' }
         )
 
         expect(result).to.be.an.object()


### PR DESCRIPTION
In https://github.com/dhis2/app-hub/pull/543 we moved to a separate query to get the total-count. This was mainly due to usecases that used `distinct`. However this was solved by modifying the `appVersion`-query to not need `distinct`. 

Even though the performance seem to not really be measurable (locally it\s below 10 ms), the latency from our server to RDS is bigger than that. Even though it is fine for now, it is an unnecessary default and I've implemented a way for each query to be able to specify their strategy, according to the needs of that particular query. The default is back to use `count() over()`, a window function that uses the entire result set (even in case of offsets). We still have to count all tuples, but it's done in one query now.

These options are available:

- `window`as explained above
- `separate` - use a separate query for the total
- `slice`- fetches entire result and slices the result in memory according to paging-object.

Note that this is only used in `appVersion` service for now, so this does not affect other services/queries. But we will migrate more services to use this helper soon™️. 