### PR TITLE
fix: save org-email

### DIFF
--- a/client/src/pages/UserOrganisation/Modals/EditNameModal.js
+++ b/client/src/pages/UserOrganisation/Modals/EditNameModal.js
@@ -7,6 +7,8 @@ import {
     ReactFinalForm,
     InputFieldFF,
     hasValue,
+    composeValidators,
+    email,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import styles from './Modal.module.css'
@@ -17,12 +19,13 @@ const EditNameModal = ({ organisation, mutate, onClose }) => {
     const successAlert = useSuccessAlert()
     const errorAlert = useErrorAlert()
 
-    const handleSubmit = async ({ name }) => {
+    const handleSubmit = async ({ name, email }) => {
         try {
-            await api.editOrganisation(organisation.id, { name })
+            await api.editOrganisation(organisation.id, { name, email })
             mutate({
                 ...organisation,
                 name,
+                email,
             })
             successAlert.show({
                 message: `Successfully updated organisation name to ${name}`,
@@ -49,6 +52,17 @@ const EditNameModal = ({ organisation, mutate, onClose }) => {
                                 component={InputFieldFF}
                                 className={styles.field}
                                 validate={hasValue}
+                            />
+                            <ReactFinalForm.Field
+                                required
+                                name="email"
+                                label="Contact email"
+                                placeholder="Enter an email address"
+                                type="email"
+                                component={InputFieldFF}
+                                initialValue={organisation.email}
+                                className={styles.field}
+                                validate={composeValidators(hasValue, email)}
                             />
                             <ButtonStrip end>
                                 <Button onClick={onClose} disabled={submitting}>

--- a/server/src/services/organisation.js
+++ b/server/src/services/organisation.js
@@ -1,8 +1,8 @@
-const { NotFoundError } = require('../utils/errors')
-const { slugify } = require('../utils/slugify')
-const Organisation = require('../models/v2/Organisation')
 const Boom = require('@hapi/boom')
 const JWT = require('jsonwebtoken')
+const Organisation = require('../models/v2/Organisation')
+const { NotFoundError } = require('../utils/errors')
+const { slugify } = require('../utils/slugify')
 
 const getOrganisationQuery = db =>
     db('organisation').select(
@@ -45,12 +45,13 @@ const ensureUniqueSlug = async (slug, knex) => {
  * @param {string} data.userId User id creating the data
  * @param {*} db
  */
-const create = async ({ userId, name }, db) => {
+const create = async ({ userId, name, email }, db) => {
     const slug = await ensureUniqueSlug(slugify(name), db)
     const obj = {
         owner: userId,
         name,
         slug,
+        email,
     }
     const dbData = Organisation.formatDatabaseJson(obj)
     const [organisation] = await db('organisation')
@@ -138,9 +139,7 @@ const update = async (id, updateData, db) => {
         dbData.slug = slug
     }
 
-    return db('organisation')
-        .update(dbData)
-        .where({ id })
+    return db('organisation').update(dbData).where({ id })
 }
 
 const addUserById = async (id, userId, db) => {
@@ -162,9 +161,7 @@ const removeUser = async (id, userId, db) => {
     return query
 }
 const remove = async (id, db) => {
-    await db('organisation')
-        .where({ id })
-        .delete()
+    await db('organisation').where({ id }).delete()
 }
 
 const hasUser = async (id, userId, knex) => {


### PR DESCRIPTION
A few bugs made saving the email of the organisation not work at all.

Seems like after the UI refactor, the email field for editing the org-email was not included in the modal.
Also, the route-handler did not pass the email-param to the service when creating an org.
The result was that both these bugs made it virtually  impossible to actually save the email of an organisation.



