### PR TITLE
fix(filter): properly include version if maxDhisVersion is empty

### DIFF
--- a/server/seeds/04_appchannel.js
+++ b/server/seeds/04_appchannel.js
@@ -46,7 +46,20 @@ exports.seed = async knex => {
             min_dhis2_version: '2.32',
             created_by_user_id: dhis2AppVersions[2].created_by_user_id,
         },
-
+        {
+            app_version_id: dhis2AppVersions[3].id,
+            channel_id: canaryId,
+            min_dhis2_version: '2.33',
+            max_dhis2_version: '2.40',
+            created_by_user_id: dhis2AppVersions[3].created_by_user_id,
+        },
+        {
+            app_version_id: dhis2AppVersions[4].id,
+            channel_id: canaryId,
+            min_dhis2_version: '2.33',
+            max_dhis2_version: '',
+            created_by_user_id: dhis2AppVersions[4].created_by_user_id,
+        },
         {
             app_version_id: whoAppVersions[0].id,
             channel_id: stableId,

--- a/server/seeds/mock/appversions.js
+++ b/server/seeds/mock/appversions.js
@@ -42,6 +42,22 @@ const dhis2AppVersions = [
         version: '0.3-dev',
         created_at: createdAtDate(),
     },
+    {
+        id: '2812d245-96de-42c4-b651-25cb313414d6',
+        app_id: dhis2App.id,
+        created_by_user_id: dhis2App.created_by_user_id,
+        version: '1.0.0',
+        created_at: createdAtDate(),
+    },
+    {
+        id: '7be62020-5bcf-4d32-a83b-b2412bcd01bb',
+        app_id: dhis2App.id,
+        created_by_user_id: dhis2App.created_by_user_id,
+        version: '1.1.0',
+        created_at: createdAtDate(),
+    },
+
+
 ]
 const whoAppVersions = [
     {

--- a/server/seeds/mock/appversions_localized.js
+++ b/server/seeds/mock/appversions_localized.js
@@ -76,6 +76,22 @@ const dhis2AppVersionsLocalized = [
         'En fin WHO app',
         'Detta är en mycket fin applikation, ostabil utvecklings-version.'
     ),
+    mockAppVersion(
+        'b6ce3233-90d1-40fa-a1cf-d148e3025616',
+        dhis2AppVersions,
+        3,
+        'en',
+        'A nice app',
+        'This is a really nice app by DHIS2!'
+    ),
+    mockAppVersion(
+        '564e6388-5d7e-4bac-a093-d80e3471ad1a',
+        dhis2AppVersions,
+        4,
+        'en',
+        'A nice app',
+        'This is a really nice app by DHIS2!'
+    ),
 ]
 
 const whoAppVersionsLocalized = [

--- a/server/src/utils/Filter.js
+++ b/server/src/utils/Filter.js
@@ -125,7 +125,7 @@ class Filters {
             query.where(builder => {
                 builder.where(nameToUse, toSQLOperator(operator, value), value)
                 if (settings.includeEmpty) {
-                    builder.orWhereRaw(`nullif( ??, ' ') is null`, nameToUse)
+                    builder.orWhereRaw(`nullif( ??, '') is null`, nameToUse)
                 }
             })
             this.markApplied(fieldName)
@@ -164,7 +164,7 @@ class Filters {
                 [colName, filter.value]
             )
             if (options.includeEmpty) {
-                builder.orWhereRaw(`nullif( ??, ' ') is null`, colName)
+                builder.orWhereRaw(`nullif( ??, '') is null`, colName)
             }
         })
         this.markApplied(filterName)

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -321,10 +321,12 @@ describe('v2/appVersions', () => {
                 const allVersions = allVersionRes.result.result
                 expect(allVersions.length).to.above(3) // should have at atleast 4 versions
 
-                const emptyMax = [null, '']
+                const emptyValues = [null, '']
                 const totalEmptyCount = allVersions.reduce(
                     (acc, curr) =>
-                        emptyMax.includes(curr.maxDhisVersion) ? acc + 1 : acc,
+                        emptyValues.includes(curr.maxDhisVersion)
+                            ? acc + 1
+                            : acc,
                     0
                 )
 
@@ -338,7 +340,6 @@ describe('v2/appVersions', () => {
                 expect(res.statusCode).to.equal(200)
 
                 const result = res.result
-                console.log('maxRes', result)
                 const versions = result.result
 
                 expect(versions.length).to.be.above(0)
@@ -348,7 +349,9 @@ describe('v2/appVersions', () => {
                 // check that it still returns empty maxDhisVersions
                 const emptyCount = versions.reduce(
                     (acc, curr) =>
-                        emptyMax.includes(curr.maxDhisVersion) ? acc + 1 : acc,
+                        emptyValues.includes(curr.maxDhisVersion)
+                            ? acc + 1
+                            : acc,
                     0
                 )
                 expect(emptyCount).to.equal(totalEmptyCount)

--- a/server/test/routes/v2/appVersions.js
+++ b/server/test/routes/v2/appVersions.js
@@ -137,10 +137,8 @@ describe('v2/appVersions', () => {
                 expect(res.statusCode).to.equal(200)
 
                 const result = res.result
-                console.log(result)
                 const versions = result.result
 
-                console.log(versions)
                 Joi.assert(versions, Joi.array().items(AppVersionModel.def))
                 versions.forEach(v => {
                     expect(v.appId).to.be.a.string()
@@ -295,12 +293,11 @@ describe('v2/appVersions', () => {
                 const versions = result.result
 
                 expect(versions.length).to.be.above(0)
-                console.log('verz', versions)
+
                 Joi.assert(versions, Joi.array().items(AppVersionModel.def))
                 versions.forEach(v => {
                     expect(v.appId).to.be.a.string()
                     expect(v.version).to.be.a.string()
-                    console.log('maxz', v.maxDhisVersion)
                     if (v.maxDhisVersion) {
                         const [, major] = v.maxDhisVersion
                             .split('.')
@@ -322,11 +319,11 @@ describe('v2/appVersions', () => {
                 expect(allVersions.length).to.above(3) // should have at atleast 4 versions
 
                 const emptyValues = [null, '']
+                const countEmptyMaxVersion = (acc, curr) =>
+                    emptyValues.includes(curr.maxDhisVersion) ? acc + 1 : acc
+
                 const totalEmptyCount = allVersions.reduce(
-                    (acc, curr) =>
-                        emptyValues.includes(curr.maxDhisVersion)
-                            ? acc + 1
-                            : acc,
+                    countEmptyMaxVersion,
                     0
                 )
 
@@ -347,13 +344,7 @@ describe('v2/appVersions', () => {
                 Joi.assert(versions, Joi.array().items(AppVersionModel.def))
 
                 // check that it still returns empty maxDhisVersions
-                const emptyCount = versions.reduce(
-                    (acc, curr) =>
-                        emptyValues.includes(curr.maxDhisVersion)
-                            ? acc + 1
-                            : acc,
-                    0
-                )
+                const emptyCount = versions.reduce(countEmptyMaxVersion, 0)
                 expect(emptyCount).to.equal(totalEmptyCount)
             })
         })


### PR DESCRIPTION
Empty `maxDhisVersion` (`''`) should now properly be included when filtering on `maxDhisVersion`.
This was probably not caught due to me reading somewhere that `nullif('', ' ')` should return true (with any blank string), but that is not the case in postgres- which makes sense. And most tests used `lte`, which included the empty-string regardless of the `or nullif`-case. 

Also added some more tests and related seeds.

On a slightly related note, we should've some better constraints/checks for `maxDhisVersion` and `minDhisVersion`, as currently they allow anything to be stored. At least we should protect against this in the application-layer/Joi-validation.