### PR TITLE
fix: hide apps in header-menu when not logged in

### DIFF
--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -16,7 +16,7 @@ const NotLoggedInIcon = () => {
 
     return (
         <button className={styles.signInButton} onClick={loginWithRedirect}>
-            Sign in
+            Developer Sign in
         </button>
     )
 }
@@ -65,12 +65,12 @@ const ProfileButton = () => {
                 </span>
             </DropdownMenuItemLink>
             <Divider dense />
-            <DropdownMenuItemLink to="/user">Your apps</DropdownMenuItemLink>
+            <DropdownMenuItemLink to="/user">My apps</DropdownMenuItemLink>
             <DropdownMenuItemLink to="/user/organisations">
-                Your organisations
+                My organisations
             </DropdownMenuItemLink>
             <DropdownMenuItemLink to="/user/apikey">
-                Your API keys
+                My API keys
             </DropdownMenuItemLink>
             <Divider dense />
             <DropdownMenuItem onClick={handleLogout}>Sign out</DropdownMenuItem>

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -16,7 +16,7 @@ const NotLoggedInIcon = () => {
 
     return (
         <button className={styles.signInButton} onClick={loginWithRedirect}>
-            Developer Sign in
+            Sign in
         </button>
     )
 }
@@ -65,12 +65,12 @@ const ProfileButton = () => {
                 </span>
             </DropdownMenuItemLink>
             <Divider dense />
-            <DropdownMenuItemLink to="/user">My apps</DropdownMenuItemLink>
+            <DropdownMenuItemLink to="/user">Your apps</DropdownMenuItemLink>
             <DropdownMenuItemLink to="/user/organisations">
-                My organisations
+                Your organisations
             </DropdownMenuItemLink>
             <DropdownMenuItemLink to="/user/apikey">
-                My API keys
+                Your API keys
             </DropdownMenuItemLink>
             <Divider dense />
             <DropdownMenuItem onClick={handleLogout}>Sign out</DropdownMenuItem>

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -84,30 +84,35 @@ const NavLink = props => (
     <NavLink_ activeClassName={styles.activeNavLink} {...props}></NavLink_>
 )
 
-const Header = () => (
-    <header className={styles.header}>
-        <nav className={styles.nav}>
-            <Link to="/" className={styles.brand}>
-                <LogoIconWhite className={styles.brandLogo} />
-                <h1 className={styles.brandText}>DHIS2 App Hub</h1>
-            </Link>
+const Header = () => {
+    const { isAuthenticated } = useAuth0()
+    return (
+        <header className={styles.header}>
+            <nav className={styles.nav}>
+                <Link to="/" className={styles.brand}>
+                    <LogoIconWhite className={styles.brandLogo} />
+                    <h1 className={styles.brandText}>DHIS2 App Hub</h1>
+                </Link>
 
-            <ul className={styles.navLinks}>
-                <li className={styles.navLink}>
-                    <NavLink exact to="/">
-                        All apps
-                    </NavLink>
-                </li>
-                <li className={styles.yourAppsLink}>
-                    <NavLink exact to="/user">
-                        Your apps
-                    </NavLink>
-                </li>
-            </ul>
-        </nav>
+                <ul className={styles.navLinks}>
+                    <li className={styles.navLink}>
+                        <NavLink exact to="/">
+                            All apps
+                        </NavLink>
+                    </li>
+                    <li className={styles.yourAppsLink}>
+                        {isAuthenticated && (
+                            <NavLink exact to="/user">
+                                My apps
+                            </NavLink>
+                        )}
+                    </li>
+                </ul>
+            </nav>
 
-        <ProfileButton />
-    </header>
-)
+            <ProfileButton />
+        </header>
+    )
+}
 
 export default Header

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -103,7 +103,7 @@ const Header = () => {
                     <li className={styles.yourAppsLink}>
                         {isAuthenticated && (
                             <NavLink exact to="/user">
-                                My apps
+                                Your apps
                             </NavLink>
                         )}
                     </li>


### PR DESCRIPTION
Hide apps-menu in header bar when not logged in.

Also renames "Your apps" to "My apps", and other related menu-items, as suggested by @germanviscuso .