### PR TITLE
fix: improve UX of invalid image filetype errors

### DIFF
--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -52,7 +52,7 @@ const EditLogo = ({ appId, logo, mutate }) => {
             <form style={{ display: 'none' }} ref={formEl}>
                 <input
                     type="file"
-                    accept="image/*"
+                    accept="image/jpeg,image/png"
                     onChange={handleUpload}
                     ref={inputEl}
                 />

--- a/client/src/pages/UserApp/ScreenshotsCard/UploadScreenshot.js
+++ b/client/src/pages/UserApp/ScreenshotsCard/UploadScreenshot.js
@@ -53,7 +53,7 @@ const UploadScreenshot = ({ appId, mutate }) => {
                 <input
                     type="file"
                     multiple
-                    accept="image/*"
+                    accept="image/jpeg,image/png"
                     onChange={handleUpload}
                     ref={inputEl}
                 />

--- a/client/src/pages/UserAppUpload/UserAppUpload.js
+++ b/client/src/pages/UserAppUpload/UserAppUpload.js
@@ -407,8 +407,8 @@ const UserAppUpload = ({ user }) => {
                                 required
                                 name="logo"
                                 buttonLabel="Upload a logo"
-                                accept="image/*"
-                                helpText="Only .jpg, .png and .gif files, 2MB max size"
+                                accept="image/jpeg,image/png"
+                                helpText="Only .jpg and .png files, 2MB max size"
                                 component={FileInputFieldFF}
                                 className={styles.field}
                                 validate={hasValue}

--- a/server/src/utils/validateMime.js
+++ b/server/src/utils/validateMime.js
@@ -5,7 +5,7 @@ const Path = require('path')
 const allowedImageMimeTypes = ['image/jpeg', 'image/png']
 const imageMetadataSchema = Joi.object({
     headers: Joi.object({
-        'content-type': Joi.string().valid(...allowedImageMimeTypes),
+        'content-type': Joi.string(),
     }).unknown(),
     filename: Joi.string(),
 }).unknown()
@@ -28,7 +28,7 @@ const validateExtensionForMimeType = (mimos, filePath, mimeTypes) => {
     if (mimeExtensions.includes(ext)) {
         return true
     }
-    throw Boom.badRequest(`File extension must be one of [${mimeExtensions}]`)
+    throw Boom.badRequest(`File extension must be one of [${mimeExtensions.join(', ')}]`)
 }
 
 module.exports = {


### PR DESCRIPTION
- Sets the accepted filetypes for various `<input type="file">` inputs used across the app for image uploads to `image/jpeg,image/png`.
- Improves the error message shown to users when an attempt at uploading an invalid image file is made

## Before
![image](https://user-images.githubusercontent.com/4295266/150565661-c9bb9461-2282-4310-ab96-5a508cf8dc3b.png)

## After
![image](https://user-images.githubusercontent.com/4295266/150565780-0596fafb-c622-440e-abb3-09a8426b974d.png)
