### PR TITLE
fix(add app): allow clearing optional select field

### DIFF
--- a/client/src/pages/UserAppUpload/UserAppUpload.js
+++ b/client/src/pages/UserAppUpload/UserAppUpload.js
@@ -314,6 +314,7 @@ const UserAppUpload = ({ user }) => {
                                 className={styles.field}
                                 validate={maxDhisVersionValidator}
                                 options={dhisVersionOptions}
+                                clearable
                             />
                         </section>
 


### PR DESCRIPTION
This is untested but should work. The instructions for locally installing the app hub are very clear, but it seemed like quite a bit of work to do for a one-line fix.