### PR TITLE
fix(apps): fix sourceUrl being cleared when version is uploaded

### DIFF
--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -4,7 +4,7 @@ const debug = require('debug')(
 const { MediaType } = require('../../../../enums')
 const getServerUrl = require('../../../../utils/getServerUrl')
 
-const convertDbAppViewRowToAppApiV1Object = app => ({
+const convertDbAppViewRowToAppApiV1Object = (app) => ({
     appType: app.type,
 
     status: app.status,
@@ -78,7 +78,7 @@ const convertAll = (apps, request) => {
     debug(`Using serverUrl: ${serverUrl}`)
 
     const formattedApps = {}
-    apps.forEach(app => {
+    apps.forEach((app) => {
         let currentApp = formattedApps[app.app_id]
 
         if (!currentApp) {
@@ -90,7 +90,7 @@ const convertAll = (apps, request) => {
         if (app.media_id !== null) {
             const media = convertAppToV1Media(app, serverUrl)
 
-            if (!currentApp.images.find(img => img.id === media.id)) {
+            if (!currentApp.images.find((img) => img.id === media.id)) {
                 currentApp.images.push(media)
             }
 
@@ -100,9 +100,17 @@ const convertAll = (apps, request) => {
             })
         }
 
+        // some app-version may not have a version set
+        // sourceUrl really should be in 'app'-table, not 'app_version'
+        if (app.source_url && !currentApp.sourceUrl) {
+            currentApp.sourceUrl = app.source_url
+        }
+
         //Prevent duplicate versions
         if (
-            !currentApp.versions.find(version => version.id === app.version_id)
+            !currentApp.versions.find(
+                (version) => version.id === app.version_id
+            )
         ) {
             currentApp.versions.push(convertAppToV1AppVersion(app, serverUrl))
         }


### PR DESCRIPTION
Fixes `sourceUrl` being cleared in the UI when a new version is uploaded. This is done by making sure any app-version sourceUrl is used, not just the first being "collected". This is the easiest fix that I could come up with that does not need to run any migration to populate missing sourceUrls.


The reason for this is that `source_url` is in the `app_version`-table. It really should be in the "app"-table, because we should not have different `source_url`s for each version. I guess this was done in good spirit, making it possible to "migrate" source to another repository host between versions - but it's such an obscure use-case and results in tons of duplicated data.

I've not done any database fixes, because that is much more work and quite risky. I think we can do that once we introduce a "v2/apps"-API. 