### PR TITLE
fix: use unambiguous short date [HUB-149]

### DIFF
--- a/client/src/components/Versions/VersionsTable/VersionsTable.js
+++ b/client/src/components/Versions/VersionsTable/VersionsTable.js
@@ -64,9 +64,14 @@ const VersionsTable = ({ versions, renderDeleteVersionButton }) => {
                         </TableCell>
                         <TableCell>
                             <span title={new Date(version.createdAt)}>
-                                {new Date(
-                                    version.createdAt
-                                ).toLocaleDateString()}
+                                {new Date(version.createdAt).toLocaleDateString(
+                                    'en-GB',
+                                    {
+                                        month: 'short',
+                                        day: 'numeric',
+                                        year: 'numeric',
+                                    }
+                                )}
                             </span>
                         </TableCell>
                         <TableCell>


### PR DESCRIPTION
Update to default d Mon YYYY. If we support internationalization in the future, we can pass the appropriate language/locale to toLocaleDateString

**Before:**
<img width="939" alt="image" src="https://user-images.githubusercontent.com/18490902/203519422-aa1a0296-cd81-46d5-a7c1-376d2e1645fa.png">


**After:**
<img width="937" alt="image" src="https://user-images.githubusercontent.com/18490902/203519484-02946f7e-96ce-400a-a81a-8885b7d48660.png">

This will also be consistent across browsers now (previously, I was getting in 6/11/2022 in Chrome and 11/6/2022 in Firefox :ugh:)