### PR TITLE
fix: break version sentences [HUB-150]

### DIFF
--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -56,14 +56,19 @@ const AboutSection = ({ appDescription, latestVersion, sourceUrl }) => (
             <a download href={latestVersion.downloadUrl} tabIndex="-1">
                 <Button primary>Download latest version</Button>
             </a>
-            <p className={styles.latestVersionDescription}>
-                {config.ui.appChannelToDisplayName[latestVersion.channel]}{' '}
-                release v{latestVersion.version}. Compatible with DHIS2{' '}
-                {renderDhisVersionsCompatibility(
-                    latestVersion.minDhisVersion,
-                    latestVersion.maxDhisVersion
-                )}
-            </p>
+            <div className={styles.latestVersionDescription}>
+                <span>
+                    {config.ui.appChannelToDisplayName[latestVersion.channel]}{' '}
+                    release v{latestVersion.version}.
+                </span>
+                <span>
+                    Compatible with DHIS2{' '}
+                    {renderDhisVersionsCompatibility(
+                        latestVersion.minDhisVersion,
+                        latestVersion.maxDhisVersion
+                    )}.
+                </span>
+            </div>
             {sourceUrl && (
                 <>
                     <Divider margin="12px 0" className={styles.divider} />

--- a/client/src/pages/AppView/AppView.module.css
+++ b/client/src/pages/AppView/AppView.module.css
@@ -70,12 +70,17 @@
 }
 
 .latestVersionDescription {
-    max-width: 168px;
     margin-top: var(--spacers-dp8);
     margin-bottom: 0;
+}
+
+.latestVersionDescription span {
+    display: block;
+    margin-bottom: 2px;
     font-size: 11px;
     color: var(--colors-grey700);
 }
+
 
 .divider {
     max-width: 80%;


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/18490902/203520280-d15605d5-5d5c-4cbc-b571-e8d5611fd02f.png)

**After**
![image](https://user-images.githubusercontent.com/18490902/203520442-0a93ab4e-9361-4e21-9d1e-2f0fdefcf439.png)

I removed the max-width on the text because it seems like it will not overflow the button length that much in most cases (and the button width would be language dependent if we internationalized in the future). If we keep the max-width, the second sentence in this example `Compatible with DHIS2 3.33 and above.` would have been on two lines, which I thought  looked a bit odder.