### PR TITLE
feat: expose plugins and changelog in the API and app

### DIFF
--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -13,7 +13,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v3
               with:
-                  node-version: 16
+                  node-version: 20
                   cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-bullseye as build
+FROM node:20-bullseye as build
 
 ENV NODE_ENV=development
 
@@ -14,7 +14,7 @@ RUN tar zxvf client/app-hub-client.tgz --directory server/
 RUN mv server/package/build server/static && rm -rf server/package
 
 # runtime image
-FROM node:14-bullseye-slim
+FROM node:20-bullseye-slim
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
         'no-unused-vars': ['error', { ignoreRestSiblings: true }],
         'react/no-unescaped-entities': 'off',
         'react/react-in-jsx-scope': 'off',
+        'import/extensions': 'off',
     },
     globals: {
         __APP_INFO__: 'readonly',

--- a/client/src/AppHub.js
+++ b/client/src/AppHub.js
@@ -11,6 +11,7 @@ import ProtectedRoute from './components/auth/ProtectedRoute'
 import Header from './components/Header/Header'
 import Apps from './pages/Apps/Apps'
 import AppView from './pages/AppView/AppView'
+import OrganisationView from './pages/OrganisationView/OrganisationView'
 import OrganisationInvitation from './pages/OrganisationInvitation/OrganisationInvitation'
 import OrganisationInvitationCallback from './pages/OrganisationInvitationCallback/OrganisationInvitationCallback'
 import UserView from './pages/UserView/UserView'
@@ -36,6 +37,10 @@ const AppHub = () => (
                             <Switch>
                                 <Route exact path="/" component={Apps} />
                                 <Route path="/app/:appId" component={AppView} />
+                                <Route
+                                    path="/organisation/:organisationSlug/view"
+                                    component={OrganisationView}
+                                />
                                 <ProtectedRoute
                                     path="/user"
                                     auth={Auth}

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -322,7 +322,7 @@ export function addOrganisation({ name, email }) {
     )
 }
 
-export function editOrganisation(id, { name, owner, email }) {
+export function editOrganisation(id, { name, owner, email, description }) {
     return apiV2.request(
         `organisations/${id}`,
         {
@@ -330,7 +330,7 @@ export function editOrganisation(id, { name, owner, email }) {
         },
         {
             method: 'PATCH',
-            body: JSON.stringify({ name, owner, email }),
+            body: JSON.stringify({ name, owner, email, description }),
             headers: {
                 'content-type': 'application/json',
             },

--- a/client/src/components/PluginTag/PluginTag.js
+++ b/client/src/components/PluginTag/PluginTag.js
@@ -1,0 +1,12 @@
+import { Tag } from '@dhis2/ui'
+
+const PluginTag = ({ hasPlugin, pluginType }) => {
+    if (!hasPlugin) {
+        return null
+    }
+    const tagString = pluginType ? `Plugin: ${pluginType}` : 'Plugin'
+
+    return <Tag neutral>{tagString}</Tag>
+}
+
+export default PluginTag

--- a/client/src/components/Versions/ChangeLogViewer.js
+++ b/client/src/components/Versions/ChangeLogViewer.js
@@ -1,21 +1,22 @@
-import { CircularLoader, Modal, ModalContent } from '@dhis2/ui'
+import { CenteredContent, CircularLoader, Modal, ModalContent } from '@dhis2/ui'
 import { useQuery } from 'src/api'
 
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 // ToDo: this is a just a placeholder for a  basic Changelog viewer
-const ChangeLogViewer = ({ appId, modalShown, onCloseChangelog }) => {
+const ChangeLogViewer = ({ appId, onCloseChangelog }) => {
     const { data, loading } = useQuery(`apps/${appId}/changelog`)
 
-    if (!modalShown) {
-        return null
-    }
     return (
         <Modal onClose={onCloseChangelog}>
             <ModalContent>
                 <div>
-                    {loading && <CircularLoader large />}
+                    {loading && (
+                        <CenteredContent>
+                            <CircularLoader large />
+                        </CenteredContent>
+                    )}
                     <ReactMarkdown>{data?.changelog}</ReactMarkdown>
                 </div>
             </ModalContent>

--- a/client/src/components/Versions/ChangeLogViewer.js
+++ b/client/src/components/Versions/ChangeLogViewer.js
@@ -1,22 +1,12 @@
-import { Modal, ModalContent } from '@dhis2/ui'
+import { CircularLoader, Modal, ModalContent } from '@dhis2/ui'
 import { useQuery } from 'src/api'
 
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 // ToDo: this is a just a placeholder for a  basic Changelog viewer
-const ChangeLogViewer = ({
-    appId,
-    versionId,
-    modalShown,
-    onCloseChangelog,
-}) => {
-    const { data, error } = useQuery(`apps/${appId}/changelog`)
-
-    // ToDo: fall back to any version?
-    const matchedVersion =
-        data?.find((v) => v.version == versionId) ??
-        data?.find((v) => !!v.changelog)
+const ChangeLogViewer = ({ appId, modalShown, onCloseChangelog }) => {
+    const { data, loading } = useQuery(`apps/${appId}/changelog`)
 
     if (!modalShown) {
         return null
@@ -24,7 +14,10 @@ const ChangeLogViewer = ({
     return (
         <Modal onClose={onCloseChangelog}>
             <ModalContent>
-                <ReactMarkdown>{matchedVersion?.changelog}</ReactMarkdown>
+                <div>
+                    {loading && <CircularLoader large />}
+                    <ReactMarkdown>{data?.changelog}</ReactMarkdown>
+                </div>
             </ModalContent>
         </Modal>
     )

--- a/client/src/components/Versions/ChangeLogViewer.js
+++ b/client/src/components/Versions/ChangeLogViewer.js
@@ -1,0 +1,33 @@
+import { Modal, ModalContent } from '@dhis2/ui'
+import { useQuery } from 'src/api'
+
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+
+// ToDo: this is a just a placeholder for a  basic Changelog viewer
+const ChangeLogViewer = ({
+    appId,
+    versionId,
+    modalShown,
+    onCloseChangelog,
+}) => {
+    const { data, error } = useQuery(`apps/${appId}/changelog`)
+
+    // ToDo: fall back to any version?
+    const matchedVersion =
+        data?.find((v) => v.version == versionId) ??
+        data?.find((v) => !!v.changelog)
+
+    if (!modalShown) {
+        return null
+    }
+    return (
+        <Modal onClose={onCloseChangelog}>
+            <ModalContent>
+                <ReactMarkdown>{matchedVersion?.changelog}</ReactMarkdown>
+            </ModalContent>
+        </Modal>
+    )
+}
+
+export default ChangeLogViewer

--- a/client/src/components/Versions/Versions.js
+++ b/client/src/components/Versions/Versions.js
@@ -103,6 +103,7 @@ const Versions = ({ appId, renderDeleteVersionButton, showDownloadCount }) => {
                     versions={versions}
                     renderDeleteVersionButton={renderDeleteVersionButton}
                     showDownloadCount={showDownloadCount}
+                    appId={appId}
                 />
             ) : (
                 <em className={styles.noVersions}>

--- a/client/src/components/Versions/VersionsTable/VersionsTable.js
+++ b/client/src/components/Versions/VersionsTable/VersionsTable.js
@@ -57,7 +57,6 @@ const VersionsTable = ({
             {changelogVisible && (
                 <ChangeLogViewer
                     appId={appId}
-                    modalShown={changelogVisible}
                     onCloseChangelog={onCloseChangelog}
                 />
             )}

--- a/client/src/components/Versions/VersionsTable/VersionsTable.js
+++ b/client/src/components/Versions/VersionsTable/VersionsTable.js
@@ -52,16 +52,15 @@ const VersionsTable = ({
         setChangelogVisible(false)
     }
 
-    // ToDO: we can infer change log from one change log
-    // const anyVersionHasChanges = !!versions.find((v) => v.hasChangelog)
-
     return (
         <>
-            <ChangeLogViewer
-                appId={appId}
-                modalShown={changelogVisible}
-                onCloseChangelog={onCloseChangelog}
-            />
+            {changelogVisible && (
+                <ChangeLogViewer
+                    appId={appId}
+                    modalShown={changelogVisible}
+                    onCloseChangelog={onCloseChangelog}
+                />
+            )}
             <Table className={styles.table}>
                 <TableHead>
                     <TableRowHead>

--- a/client/src/components/Versions/VersionsTable/VersionsTable.js
+++ b/client/src/components/Versions/VersionsTable/VersionsTable.js
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from 'react'
 import styles from './VersionsTable.module.css'
 import config from 'config'
 import { renderDhisVersionsCompatibility } from 'src/lib/render-dhis-versions-compatibility'
+import ChangeLogViewer from '../ChangeLogViewer'
 
 const { appChannelToDisplayName } = config.ui
 
@@ -39,65 +40,98 @@ const VersionsTable = ({
     versions,
     renderDeleteVersionButton,
     showDownloadCount,
+    appId,
 }) => {
     const getDownloadUrl = useCreateGetDownloadUrl()
+    const [changelogVisible, setChangelogVisible] = useState(false)
+    const showChangeLog = () => {
+        setChangelogVisible(!changelogVisible)
+    }
+
+    const onCloseChangelog = () => {
+        setChangelogVisible(false)
+    }
+
+    // ToDO: we can infer change log from one change log
+    // const anyVersionHasChanges = !!versions.find((v) => v.hasChangelog)
 
     return (
-        <Table className={styles.table}>
-            <TableHead>
-                <TableRowHead>
-                    <TableCellHead>Version</TableCellHead>
-                    <TableCellHead>Channel</TableCellHead>
-                    <TableCellHead>DHIS2 version compatibility</TableCellHead>
-                    <TableCellHead>Upload date</TableCellHead>
-                    {showDownloadCount && (
-                        <TableCellHead>Downloads</TableCellHead>
-                    )}
-                    <TableCellHead></TableCellHead>
-                </TableRowHead>
-            </TableHead>
-            <TableBody>
-                {versions.map((version) => (
-                    <TableRow key={version.id}>
-                        <TableCell>{version.version}</TableCell>
-                        <TableCell className={styles.channelNameCell}>
-                            {appChannelToDisplayName[version.channel]}
-                        </TableCell>
-                        <TableCell>
-                            {renderDhisVersionsCompatibility(
-                                version.minDhisVersion,
-                                version.maxDhisVersion
-                            )}
-                        </TableCell>
-                        <TableCell>
-                            <span title={new Date(version.createdAt)}>
-                                {new Date(
-                                    version.createdAt
-                                ).toLocaleDateString()}
-                            </span>
-                        </TableCell>
+        <>
+            <ChangeLogViewer
+                appId={appId}
+                modalShown={changelogVisible}
+                onCloseChangelog={onCloseChangelog}
+            />
+            <Table className={styles.table}>
+                <TableHead>
+                    <TableRowHead>
+                        <TableCellHead>Version</TableCellHead>
+                        <TableCellHead>Channel</TableCellHead>
+                        <TableCellHead>
+                            DHIS2 version compatibility
+                        </TableCellHead>
+                        <TableCellHead>Upload date</TableCellHead>
                         {showDownloadCount && (
-                            <TableCell>
-                                <span>{version.downloadCount}</span>
-                            </TableCell>
+                            <TableCellHead>Downloads</TableCellHead>
                         )}
-                        <TableCell>
-                            <a
-                                download
-                                href={getDownloadUrl(version.downloadUrl)}
-                                tabIndex="-1"
-                            >
-                                <Button small secondary>
-                                    Download
-                                </Button>
-                            </a>
-                            {renderDeleteVersionButton &&
-                                renderDeleteVersionButton(version)}
-                        </TableCell>
-                    </TableRow>
-                ))}
-            </TableBody>
-        </Table>
+                        <TableCellHead></TableCellHead>
+                    </TableRowHead>
+                </TableHead>
+                <TableBody>
+                    {versions.map((version) => (
+                        <TableRow key={version.id}>
+                            <TableCell>{version.version}</TableCell>
+                            <TableCell className={styles.channelNameCell}>
+                                {appChannelToDisplayName[version.channel]}
+                            </TableCell>
+                            <TableCell>
+                                {renderDhisVersionsCompatibility(
+                                    version.minDhisVersion,
+                                    version.maxDhisVersion
+                                )}
+                            </TableCell>
+                            <TableCell>
+                                <span title={new Date(version.createdAt)}>
+                                    {new Date(
+                                        version.createdAt
+                                    ).toLocaleDateString()}
+                                </span>
+                            </TableCell>
+                            {showDownloadCount && (
+                                <TableCell>
+                                    <span>{version.downloadCount}</span>
+                                </TableCell>
+                            )}
+                            <TableCell>
+                                <a
+                                    download
+                                    href={getDownloadUrl(version.downloadUrl)}
+                                    tabIndex="-1"
+                                >
+                                    <Button small secondary>
+                                        Download
+                                    </Button>
+                                </a>
+                                {renderDeleteVersionButton &&
+                                    renderDeleteVersionButton(version)}
+                                {version.hasChangelog && (
+                                    <>
+                                        {' '}
+                                        <Button
+                                            small
+                                            secondary
+                                            onClick={() => showChangeLog(appId)}
+                                        >
+                                            View Changes
+                                        </Button>
+                                    </>
+                                )}
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </>
     )
 }
 VersionsTable.propTypes = {

--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -26,6 +26,7 @@ const HeaderSection = ({
     logoSrc,
     hasPlugin,
     pluginType,
+    organisationSlug,
 }) => (
     <section
         className={classnames(styles.appCardSection, styles.appCardHeader)}
@@ -33,7 +34,15 @@ const HeaderSection = ({
         <AppIcon src={logoSrc} />
         <div>
             <h2 className={styles.appCardName}>{appName}</h2>
-            <span className={styles.appCardDeveloper}>by {appDeveloper}</span>
+            <span className={styles.appCardDeveloper}>
+                by{' '}
+                <a
+                    className={styles.link}
+                    href={`/organisation/${organisationSlug}/view`}
+                >
+                    {appDeveloper}
+                </a>
+            </span>
             <div className={styles.appCardTypeContainer}>
                 <span className={styles.appCardType}>{appType}</span>
                 {hasPlugin && (
@@ -51,6 +60,7 @@ HeaderSection.propTypes = {
     pluginType: PropTypes.string,
     hasPlugin: PropTypes.bool,
     logoSrc: PropTypes.string,
+    organisationSlug: PropTypes.string.isRequired,
 }
 
 const AboutSection = ({ appDescription, latestVersion, sourceUrl }) => (
@@ -131,6 +141,7 @@ const AppView = ({ match }) => {
             <HeaderSection
                 appName={app.name}
                 appDeveloper={appDeveloper}
+                organisationSlug={app.developer?.organisation_slug}
                 appType={config.ui.appTypeToDisplayName[app.appType]}
                 logoSrc={logoSrc}
                 hasPlugin={app.hasPlugin}

--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -3,6 +3,7 @@ import {
     CircularLoader,
     NoticeBox,
     Card,
+    Tag,
     Divider,
     Button,
 } from '@dhis2/ui'
@@ -17,7 +18,13 @@ import Screenshots from 'src/components/Screenshots/Screenshots'
 import Versions from 'src/components/Versions/Versions'
 import { renderDhisVersionsCompatibility } from 'src/lib/render-dhis-versions-compatibility'
 
-const HeaderSection = ({ appName, appDeveloper, appType, logoSrc }) => (
+const HeaderSection = ({
+    appName,
+    appDeveloper,
+    appType,
+    logoSrc,
+    hasPlugin,
+}) => (
     <section
         className={classnames(styles.appCardSection, styles.appCardHeader)}
     >
@@ -25,7 +32,10 @@ const HeaderSection = ({ appName, appDeveloper, appType, logoSrc }) => (
         <div>
             <h2 className={styles.appCardName}>{appName}</h2>
             <span className={styles.appCardDeveloper}>by {appDeveloper}</span>
-            <span className={styles.appCardType}>{appType}</span>
+            <div className={styles.appCardTypeContainer}>
+                <span className={styles.appCardType}>{appType}</span>
+                {hasPlugin && <Tag neutral>Plugin</Tag>}
+            </div>
         </div>
     </section>
 )
@@ -34,6 +44,7 @@ HeaderSection.propTypes = {
     appDeveloper: PropTypes.string.isRequired,
     appName: PropTypes.string.isRequired,
     appType: PropTypes.string.isRequired,
+    hasPlugin: PropTypes.bool,
     logoSrc: PropTypes.string,
 }
 
@@ -117,6 +128,7 @@ const AppView = ({ match }) => {
                 appDeveloper={appDeveloper}
                 appType={config.ui.appTypeToDisplayName[app.appType]}
                 logoSrc={logoSrc}
+                hasPlugin={app.hasPlugin}
             />
             <Divider />
             <AboutSection

--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -17,6 +17,7 @@ import AppIcon from 'src/components/AppIcon/AppIcon'
 import Screenshots from 'src/components/Screenshots/Screenshots'
 import Versions from 'src/components/Versions/Versions'
 import { renderDhisVersionsCompatibility } from 'src/lib/render-dhis-versions-compatibility'
+import PluginTag from '../../components/PluginTag/PluginTag'
 
 const HeaderSection = ({
     appName,
@@ -24,6 +25,7 @@ const HeaderSection = ({
     appType,
     logoSrc,
     hasPlugin,
+    pluginType,
 }) => (
     <section
         className={classnames(styles.appCardSection, styles.appCardHeader)}
@@ -34,7 +36,9 @@ const HeaderSection = ({
             <span className={styles.appCardDeveloper}>by {appDeveloper}</span>
             <div className={styles.appCardTypeContainer}>
                 <span className={styles.appCardType}>{appType}</span>
-                {hasPlugin && <Tag neutral>Plugin</Tag>}
+                {hasPlugin && (
+                    <PluginTag hasPlugin={hasPlugin} pluginType={pluginType} />
+                )}
             </div>
         </div>
     </section>
@@ -44,6 +48,7 @@ HeaderSection.propTypes = {
     appDeveloper: PropTypes.string.isRequired,
     appName: PropTypes.string.isRequired,
     appType: PropTypes.string.isRequired,
+    pluginType: PropTypes.string,
     hasPlugin: PropTypes.bool,
     logoSrc: PropTypes.string,
 }
@@ -129,6 +134,7 @@ const AppView = ({ match }) => {
                 appType={config.ui.appTypeToDisplayName[app.appType]}
                 logoSrc={logoSrc}
                 hasPlugin={app.hasPlugin}
+                pluginType={app.pluginType}
             />
             <Divider />
             <AboutSection

--- a/client/src/pages/AppView/AppView.module.css
+++ b/client/src/pages/AppView/AppView.module.css
@@ -98,12 +98,15 @@
     content: "";
 }
 
-.sourceUrl {
+.link, .sourceUrl {
     font-size: 14px;
     color: var(--colors-blue700);
     text-decoration: underline;
 }
 
-.sourceUrl:hover, .sourceUrl:focus {
+.link:hover, .sourceUrl:hover,
+.link:focus, .sourceUrl:focus {
     color: var(--colors-grey900);
 }
+
+

--- a/client/src/pages/AppView/AppView.module.css
+++ b/client/src/pages/AppView/AppView.module.css
@@ -37,9 +37,15 @@
 }
 
 .appCardType {
-    display: block;
     font-size: 13px;
     color: var(--colors-grey700);
+    margin-right: 5px;
+}
+
+.appCardTypeContainer {
+    flex-direction: 'row';
+    display: 'flex';
+    align-items: 'center';
 }
 
 .appCardHeading {
@@ -48,6 +54,7 @@
     margin-top: 0;
     margin-bottom: var(--spacers-dp12);
 }
+
 
 .appCardParagraph {
     font-size: 15px;

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
@@ -1,3 +1,4 @@
+import { Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -6,21 +7,34 @@ import styles from './AppCardItem.module.css'
 import config from 'config'
 import AppIcon from 'src/components/AppIcon/AppIcon'
 
-const AppCardItem = ({ id, name, developer, type, description, images }) => {
+const AppCardItem = ({
+    id,
+    name,
+    developer,
+    type,
+    description,
+    images,
+    hasPlugin,
+}) => {
     const logo = images.find((elem) => elem.logo)
 
     return (
         <Link to={`/app/${id}`} className={styles.appCard}>
             <header className={styles.appCardHeader}>
                 <AppIcon src={logo?.imageUrl} />
+
                 <div>
                     <h2 className={styles.appCardName}>{name}</h2>
                     <span className={styles.appCardDeveloper}>
                         {developer.organisation || 'Unspecified'}
                     </span>
-                    <span className={styles.appCardType}>
-                        {config.ui.appTypeToDisplayName[type]}
-                    </span>
+                    <div className={styles.appTypeContainer}>
+                        <span className={styles.appCardType}>
+                            {config.ui.appTypeToDisplayName[type]}
+                        </span>
+
+                        {hasPlugin && <Tag neutral>Plugin</Tag>}
+                    </div>
                 </div>
             </header>
 
@@ -52,6 +66,7 @@ AppCardItem.propTypes = {
         organisation: PropTypes.string,
     }).isRequired,
     id: PropTypes.string.isRequired,
+    hasPlugin: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     description: PropTypes.string,

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.js
@@ -1,4 +1,3 @@
-import { Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -6,15 +5,17 @@ import { Link } from 'react-router-dom'
 import styles from './AppCardItem.module.css'
 import config from 'config'
 import AppIcon from 'src/components/AppIcon/AppIcon'
+import PluginTag from '../../../../components/PluginTag/PluginTag'
 
 const AppCardItem = ({
     id,
     name,
     developer,
-    type,
+    appType,
     description,
     images,
     hasPlugin,
+    pluginType,
 }) => {
     const logo = images.find((elem) => elem.logo)
 
@@ -30,10 +31,15 @@ const AppCardItem = ({
                     </span>
                     <div className={styles.appTypeContainer}>
                         <span className={styles.appCardType}>
-                            {config.ui.appTypeToDisplayName[type]}
+                            {config.ui.appTypeToDisplayName[appType]}
                         </span>
 
-                        {hasPlugin && <Tag neutral>Plugin</Tag>}
+                        {hasPlugin && (
+                            <PluginTag
+                                hasPlugin={hasPlugin}
+                                pluginType={pluginType}
+                            />
+                        )}
                     </div>
                 </div>
             </header>
@@ -66,9 +72,10 @@ AppCardItem.propTypes = {
         organisation: PropTypes.string,
     }).isRequired,
     id: PropTypes.string.isRequired,
-    hasPlugin: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
+    hasPlugin: PropTypes.bool.isRequired,
+    pluginType: PropTypes.string.isRequired,
+    appType: PropTypes.string.isRequired,
     description: PropTypes.string,
     images: PropTypes.array,
 }

--- a/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.module.css
+++ b/client/src/pages/Apps/AppCards/AppCardItem/AppCardItem.module.css
@@ -29,9 +29,18 @@
 }
 
 .appCardDeveloper, .appCardType {
-    display: block;
     margin: var(--spacers-dp4) 0;
     font-size: 14px;
+}
+
+.appTypeContainer {
+    flex-direction: 'row';
+    display: 'flex';
+    align-items: 'center';
+}
+
+.appTypeContainer .appCardType {
+    margin-right: 5px;
 }
 
 .appCardDeveloper {

--- a/client/src/pages/Apps/AppCards/AppCards.js
+++ b/client/src/pages/Apps/AppCards/AppCards.js
@@ -31,16 +31,7 @@ const AppCards = ({ isLoading, error, apps }) => {
     return (
         <div className={styles.appCards}>
             {apps.map((app) => (
-                <AppCardItem
-                    key={app.id}
-                    id={app.id}
-                    name={app.name}
-                    developer={app.developer}
-                    type={app.appType}
-                    description={app.description}
-                    images={app.images}
-                    hasPlugin={app.hasPlugin}
-                />
+                <AppCardItem key={app.id} {...app} />
             ))}
         </div>
     )

--- a/client/src/pages/Apps/AppCards/AppCards.js
+++ b/client/src/pages/Apps/AppCards/AppCards.js
@@ -39,6 +39,7 @@ const AppCards = ({ isLoading, error, apps }) => {
                     type={app.appType}
                     description={app.description}
                     images={app.images}
+                    hasPlugin={app.hasPlugin}
                 />
             ))}
         </div>

--- a/client/src/pages/OrganisationView/OrganisationView.js
+++ b/client/src/pages/OrganisationView/OrganisationView.js
@@ -1,0 +1,53 @@
+import { Card, CenteredContent, CircularLoader } from '@dhis2/ui'
+import styles from './OrganisationView.module.css'
+import { useQuery } from '../../api'
+import AppCards from '../Apps/AppCards/AppCards'
+import { relativeTimeFormat } from 'src/lib/relative-time-format'
+
+const OrganisationView = ({ match }) => {
+    const { organisationSlug } = match.params
+
+    const { data: organisation } = useQuery(
+        `organisations/${organisationSlug}?includeApps=true&includeUsers=false`
+    )
+
+    if (!organisation) {
+        return (
+            <CenteredContent>
+                <CircularLoader large />
+            </CenteredContent>
+        )
+    }
+    return (
+        <div>
+            <Card className={styles.card}>
+                <div className={styles.header}>
+                    <div className={styles.flex}>
+                        <h2 className={styles.organisationName}>
+                            {organisation?.name}
+                        </h2>
+                    </div>
+                    <div className={styles.createdAt}>
+                        <span>{organisation?.apps?.length} apps</span>
+                        <span> | </span>
+                        <span>
+                            profile created{' '}
+                            {relativeTimeFormat(
+                                organisation?.createdAt ?? Date.now()
+                            )}
+                        </span>
+                    </div>
+                    {organisation?.description && (
+                        <div className={styles.description}>
+                            {organisation.description}
+                        </div>
+                    )}
+                </div>
+
+                <AppCards apps={organisation?.apps || []} />
+            </Card>
+        </div>
+    )
+}
+
+export default OrganisationView

--- a/client/src/pages/OrganisationView/OrganisationView.module.css
+++ b/client/src/pages/OrganisationView/OrganisationView.module.css
@@ -16,27 +16,17 @@
     margin-right: var(--spacers-dp8);
 }
 
-.description {
-    font-size: 0.8em;
-}
-
 .createdAt, .description {
     margin-top: var(--spacers-dp8);
-    color: var(--colors-grey800);
-}
+    margin-bottom: var(--spacers-dp8);
 
-.notice {
-    margin: var(--spacers-dp32) 0;
+    color: var(--colors-grey700);
+    font-size: 0.7em;
 }
+.description {
+    color: var(--colors-grey900);
+    line-height: 1.6em;
 
-.subheader {
-    display: inline-block;
-    font-size: 18px;
-    font-weight: 500;
-    color: var(--colors-grey800);
-    margin-top: 0;
-    margin-bottom: var(--spacers-dp12);
-    margin-right: var(--spacers-dp8);
 }
 
 .flex {

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -9,6 +9,7 @@ import * as api from 'src/api'
 import AppDescription from 'src/components/AppDescription/AppDescription'
 import AppIcon from 'src/components/AppIcon/AppIcon'
 import { useSuccessAlert, useErrorAlert } from 'src/lib/use-alert'
+import PluginTag from '../../../components/PluginTag/PluginTag'
 
 const { appTypeToDisplayName } = config.ui
 
@@ -91,7 +92,12 @@ const DetailsCard = ({ app, mutate }) => {
                         by {appDeveloper}
                     </span>
                     <span className={styles.detailsCardType}>{appType}</span>
-                    {app.hasPlugin && <Tag neutral>Plugin</Tag>}
+                    {app.hasPlugin && (
+                        <PluginTag
+                            hasPlugin={app.hasPlugin}
+                            pluginType={app.pluginType}
+                        />
+                    )}
                 </div>
             </section>
             <Divider />

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -1,4 +1,4 @@
-import { Card, Button, Divider } from '@dhis2/ui'
+import { Card, Button, Divider, Tag } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import { useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
@@ -91,6 +91,7 @@ const DetailsCard = ({ app, mutate }) => {
                         by {appDeveloper}
                     </span>
                     <span className={styles.detailsCardType}>{appType}</span>
+                    {app.hasPlugin && <Tag neutral>Plugin</Tag>}
                 </div>
             </section>
             <Divider />

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.js
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.js
@@ -88,8 +88,15 @@ const DetailsCard = ({ app, mutate }) => {
                 </div>
                 <div>
                     <h2 className={styles.detailsCardName}>{app.name}</h2>
+
                     <span className={styles.detailsCardDeveloper}>
-                        by {appDeveloper}
+                        by{' '}
+                        <a
+                            className={styles.link}
+                            href={`/organisation/${app.developer?.organisation_slug}/view`}
+                        >
+                            {appDeveloper}
+                        </a>
                     </span>
                     <span className={styles.detailsCardType}>{appType}</span>
                     {app.hasPlugin && (

--- a/client/src/pages/UserApp/DetailsCard/DetailsCard.module.css
+++ b/client/src/pages/UserApp/DetailsCard/DetailsCard.module.css
@@ -42,11 +42,11 @@
     max-width: 640px;
 }
 
-.sourceUrl {
+.link, .sourceUrl {
     color: var(--colors-blue700);
     text-decoration: underline;
 }
 
-.sourceUrl:hover, .sourceUrl:focus {
+.link:hover, .link:focus, .sourceUrl:hover, .sourceUrl:focus {
     color: var(--colors-grey900);
 }

--- a/client/src/pages/UserOrganisation/Modals/EditNameModal.js
+++ b/client/src/pages/UserOrganisation/Modals/EditNameModal.js
@@ -6,6 +6,7 @@ import {
     ModalContent,
     ReactFinalForm,
     InputFieldFF,
+    TextAreaFieldFF,
     hasValue,
     composeValidators,
     email,
@@ -19,13 +20,18 @@ const EditNameModal = ({ organisation, mutate, onClose }) => {
     const successAlert = useSuccessAlert()
     const errorAlert = useErrorAlert()
 
-    const handleSubmit = async ({ name, email }) => {
+    const handleSubmit = async ({ name, email, description }) => {
         try {
-            await api.editOrganisation(organisation.id, { name, email })
+            await api.editOrganisation(organisation.id, {
+                name,
+                email,
+                description,
+            })
             mutate({
                 ...organisation,
                 name,
                 email,
+                description,
             })
             successAlert.show({
                 message: `Successfully updated organisation name to ${name}`,
@@ -64,6 +70,15 @@ const EditNameModal = ({ organisation, mutate, onClose }) => {
                                 className={styles.field}
                                 validate={composeValidators(hasValue, email)}
                             />
+                            <ReactFinalForm.Field
+                                required
+                                name="description"
+                                label="Organisation description"
+                                placeholder="Enter a description"
+                                component={TextAreaFieldFF}
+                                initialValue={organisation.description}
+                                className={styles.field}
+                            />
                             <ButtonStrip end>
                                 <Button onClick={onClose} disabled={submitting}>
                                     Cancel
@@ -73,7 +88,7 @@ const EditNameModal = ({ organisation, mutate, onClose }) => {
                                     primary
                                     disabled={!valid || submitting}
                                 >
-                                    Update name
+                                    Update
                                 </Button>
                             </ButtonStrip>
                         </form>

--- a/client/src/pages/UserOrganisation/UserOrganisation.js
+++ b/client/src/pages/UserOrganisation/UserOrganisation.js
@@ -102,10 +102,13 @@ const UserOrganisation = ({ match, user }) => {
                                 secondary
                                 onClick={editNameModal.show}
                             >
-                                Edit name
+                                Edit
                             </Button>
                         </>
                     )}
+                </div>
+                <div className={styles.description}>
+                    {organisation.description || 'no description'}
                 </div>
                 <div className={styles.createdAt}>
                     Created{' '}

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -34,5 +34,6 @@ module.exports = {
         'hapi/hapi-capitalize-modules': 0,
         'hapi/hapi-for-you': 0,
         'hapi/hapi-scope-start': 0,
+        'import/extensions': 0,
     },
 }

--- a/server/migrations/20241118143001_d2config_changelog_columns.js
+++ b/server/migrations/20241118143001_d2config_changelog_columns.js
@@ -1,0 +1,110 @@
+exports.up = async (knex) => {
+    await knex.schema.table('app_version', (table) => {
+        table.json('d2config').notNullable().default('{}')
+        table.text('changelog').nullable()
+    })
+    // await knex.schema.table('app', (table) => {
+    //     table.text('d2config').nullable().notNullable().default('{}')
+    //     table.text('changelog').nullable()
+    // })
+
+    await knex.raw('DROP VIEW apps_view')
+    // update app-view with column
+    await knex.raw(`
+        CREATE VIEW apps_view AS
+        SELECT  app.id AS app_id,
+                app.type,
+                app.core_app,
+                appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url, appver.d2config, appver.changelog,
+                json_extract_path(d2config , 'entryPoints', 'plugin') AS plugin,
+                media.app_media_id AS media_id, media.original_filename, media.created_at AS media_created_at, media.media_type,
+                localisedapp.language_code, localisedapp.name, localisedapp.description, localisedapp.slug AS appver_slug,
+                s.status, s.created_at AS status_created_at,
+                ac.min_dhis2_version, ac.max_dhis2_version,
+                c.name AS channel_name, c.id AS channel_id,
+                app.contact_email AS contact_email,
+                users.id as owner_id, users.name as owner_name, users.email as owner_email,
+                org.name AS organisation, org.slug AS organisation_slug, org.email as organisation_email
+
+            FROM app
+
+            INNER JOIN app_status AS s
+                ON s.app_id = app.id
+
+            INNER JOIN app_version AS appver
+                ON appver.app_id = s.app_id
+
+            LEFT JOIN app_media_view AS media
+                ON media.app_id = s.app_id
+
+            INNER JOIN app_version_localised AS localisedapp
+                ON localisedapp.app_version_id = appver.id
+
+            INNER JOIN app_channel AS ac
+                ON ac.app_version_id = appver.id
+
+            INNER JOIN channel AS c
+                ON c.id = ac.channel_id
+
+            INNER JOIN users
+                ON users.id = app.created_by_user_id
+
+            INNER JOIN organisation AS org
+                ON org.id = app.organisation_id
+    `)
+}
+
+exports.down = async (knex) => {
+    await knex.schema.table('app_version', (table) => {
+        table.dropColumn('d2config')
+        table.dropColumn('changelog')
+    })
+
+    // await knex.schema.table('app', (table) => {
+    //     table.dropColumn('d2config')
+    //     table.dropColumn('changelog')
+    // })
+
+    await knex.raw('DROP VIEW apps_view')
+    await knex.raw(`
+    CREATE VIEW apps_view AS
+    SELECT  app.id AS app_id,
+            app.type,
+            app.core_app,
+            appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url,
+            media.app_media_id AS media_id, media.original_filename, media.created_at AS media_created_at, media.media_type,
+            localisedapp.language_code, localisedapp.name, localisedapp.description, localisedapp.slug AS appver_slug,
+            s.status, s.created_at AS status_created_at,
+            ac.min_dhis2_version, ac.max_dhis2_version,
+            c.name AS channel_name, c.id AS channel_id,
+            app.contact_email AS contact_email,
+            users.id as owner_id, users.name as owner_name, users.email as owner_email,
+            org.name AS organisation, org.slug AS organisation_slug, org.email as organisation_email
+
+        FROM app
+
+        INNER JOIN app_status AS s
+            ON s.app_id = app.id
+
+        INNER JOIN app_version AS appver
+            ON appver.app_id = s.app_id
+
+        LEFT JOIN app_media_view AS media
+            ON media.app_id = s.app_id
+
+        INNER JOIN app_version_localised AS localisedapp
+            ON localisedapp.app_version_id = appver.id
+
+        INNER JOIN app_channel AS ac
+            ON ac.app_version_id = appver.id
+
+        INNER JOIN channel AS c
+            ON c.id = ac.channel_id
+
+        INNER JOIN users
+            ON users.id = app.created_by_user_id
+
+        INNER JOIN organisation AS org
+            ON org.id = app.organisation_id
+`)
+}

--- a/server/migrations/20241118143001_d2config_changelog_columns.js
+++ b/server/migrations/20241118143001_d2config_changelog_columns.js
@@ -1,9 +1,9 @@
 exports.up = async (knex) => {
     await knex.schema.table('app_version', (table) => {
         table.text('change_summary').nullable()
+        table.jsonb('d2config').nullable().notNullable().default('{}')
     })
     await knex.schema.table('app', (table) => {
-        table.jsonb('d2config').nullable().notNullable().default('{}')
         table.text('changelog').nullable()
     })
 
@@ -14,9 +14,11 @@ exports.up = async (knex) => {
         SELECT  app.id AS app_id,
                 app.type,
                 app.core_app,
-                appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url,  appver.change_summary,
-                app.d2config, app.changelog,
+                app.changelog,
+                appver.version, appver.id AS version_id, appver.created_at AS version_created_at, appver.source_url, appver.demo_url,
+                appver.d2config, appver.change_summary,
                 jsonb_extract_path_text(d2config , 'entryPoints', 'plugin') <> '' AS has_plugin,
+                jsonb_extract_path_text(d2config , 'pluginType') AS plugin_type,
                 media.app_media_id AS media_id, media.original_filename, media.created_at AS media_created_at, media.media_type,
                 localisedapp.language_code, localisedapp.name, localisedapp.description, localisedapp.slug AS appver_slug,
                 s.status, s.created_at AS status_created_at,
@@ -57,10 +59,10 @@ exports.up = async (knex) => {
 exports.down = async (knex) => {
     await knex.schema.table('app_version', (table) => {
         table.dropColumn('version_change_summary')
+        table.dropColumn('d2config')
     })
 
     await knex.schema.table('app', (table) => {
-        table.dropColumn('d2config')
         table.dropColumn('changelog')
     })
 

--- a/server/migrations/20241210123044_organisation_description.js
+++ b/server/migrations/20241210123044_organisation_description.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+    await knex.schema.table('organisation', (table) => {
+        table.string('description', 1000).nullable()
+    })
+}
+
+exports.down = async (knex) => {
+    await knex.schema.table('organisation', (table) => {
+        table.dropColumn('description')
+    })
+}

--- a/server/src/data/createApp.js
+++ b/server/src/data/createApp.js
@@ -14,7 +14,6 @@ const paramsSchema = joi
             .valid(...AppTypes),
         coreApp: joi.bool(),
         changelog: joi.string().allow('', null),
-        d2config: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
 
@@ -43,15 +42,7 @@ const createApp = async (params, knex) => {
     }
 
     debug('params: ', params)
-    const {
-        userId,
-        contactEmail,
-        orgId,
-        appType,
-        coreApp,
-        d2config,
-        changelog,
-    } = params
+    const { userId, contactEmail, orgId, appType, coreApp, changelog } = params
 
     //generate a new uuid to insert
 
@@ -64,7 +55,6 @@ const createApp = async (params, knex) => {
                 organisation_id: orgId,
                 type: appType,
                 core_app: coreApp,
-                d2config,
                 changelog,
             })
             .returning('id')

--- a/server/src/data/createApp.js
+++ b/server/src/data/createApp.js
@@ -13,6 +13,8 @@ const paramsSchema = joi
             .required()
             .valid(...AppTypes),
         coreApp: joi.bool(),
+        changelog: joi.string().allow('', null),
+        d2config: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
 
@@ -41,7 +43,15 @@ const createApp = async (params, knex) => {
     }
 
     debug('params: ', params)
-    const { userId, contactEmail, orgId, appType, coreApp } = params
+    const {
+        userId,
+        contactEmail,
+        orgId,
+        appType,
+        coreApp,
+        d2config,
+        changelog,
+    } = params
 
     //generate a new uuid to insert
 
@@ -54,6 +64,8 @@ const createApp = async (params, knex) => {
                 organisation_id: orgId,
                 type: appType,
                 core_app: coreApp,
+                d2config,
+                changelog,
             })
             .returning('id')
 

--- a/server/src/data/createAppVersion.js
+++ b/server/src/data/createAppVersion.js
@@ -12,6 +12,8 @@ const paramsSchema = joi
         demoUrl: joi.string().uri().allow('', null),
         sourceUrl: joi.string().uri().allow('', null),
         version: joi.string().allow(''),
+        changelog: joi.string().allow('', null),
+        d2config: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
 
@@ -41,7 +43,8 @@ const createAppVersion = async (params, knex) => {
         throw paramsValidation.error
     }
 
-    const { userId, appId, demoUrl, sourceUrl, version } = params
+    const { userId, appId, demoUrl, sourceUrl, version, changelog, d2config } =
+        params
     debug('got params: ', params)
 
     try {
@@ -57,6 +60,8 @@ const createAppVersion = async (params, knex) => {
                 demo_url: demoUrl || '',
                 source_url: sourceUrl || '',
                 version: version || '',
+                changelog,
+                d2config,
             })
             .returning('id')
 
@@ -67,6 +72,8 @@ const createAppVersion = async (params, knex) => {
             demoUrl,
             sourceUrl,
             version,
+            changelog,
+            d2config,
         }
     } catch (err) {
         throw new Error(

--- a/server/src/data/createAppVersion.js
+++ b/server/src/data/createAppVersion.js
@@ -12,6 +12,7 @@ const paramsSchema = joi
         demoUrl: joi.string().uri().allow('', null),
         sourceUrl: joi.string().uri().allow('', null),
         version: joi.string().allow(''),
+        d2config: joi.string().allow('', null),
         change_summary: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
@@ -42,7 +43,7 @@ const createAppVersion = async (params, knex) => {
         throw paramsValidation.error
     }
 
-    const { userId, appId, demoUrl, sourceUrl, version } = params
+    const { userId, appId, demoUrl, sourceUrl, version, d2config } = params
     debug('got params: ', params)
 
     try {
@@ -58,6 +59,7 @@ const createAppVersion = async (params, knex) => {
                 demo_url: demoUrl || '',
                 source_url: sourceUrl || '',
                 version: version || '',
+                d2config,
             })
             .returning('id')
 
@@ -68,6 +70,7 @@ const createAppVersion = async (params, knex) => {
             demoUrl,
             sourceUrl,
             version,
+            d2config,
         }
     } catch (err) {
         throw new Error(

--- a/server/src/data/createAppVersion.js
+++ b/server/src/data/createAppVersion.js
@@ -12,8 +12,7 @@ const paramsSchema = joi
         demoUrl: joi.string().uri().allow('', null),
         sourceUrl: joi.string().uri().allow('', null),
         version: joi.string().allow(''),
-        changelog: joi.string().allow('', null),
-        d2config: joi.string().allow('', null),
+        change_summary: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
 
@@ -43,8 +42,7 @@ const createAppVersion = async (params, knex) => {
         throw paramsValidation.error
     }
 
-    const { userId, appId, demoUrl, sourceUrl, version, changelog, d2config } =
-        params
+    const { userId, appId, demoUrl, sourceUrl, version } = params
     debug('got params: ', params)
 
     try {
@@ -60,8 +58,6 @@ const createAppVersion = async (params, knex) => {
                 demo_url: demoUrl || '',
                 source_url: sourceUrl || '',
                 version: version || '',
-                changelog,
-                d2config,
             })
             .returning('id')
 
@@ -72,8 +68,6 @@ const createAppVersion = async (params, knex) => {
             demoUrl,
             sourceUrl,
             version,
-            changelog,
-            d2config,
         }
     } catch (err) {
         throw new Error(

--- a/server/src/data/getApps.js
+++ b/server/src/data/getApps.js
@@ -50,6 +50,9 @@ const getApps = (
                 builder.where((builder) => {
                     builder.where('name', 'ilike', `%${query}%`)
                     builder.orWhere('organisation', 'ilike', `%${query}%`)
+                    if (query.match(/plugin/i)) {
+                        builder.orWhere('has_plugin', true)
+                    }
                 })
             }
         })

--- a/server/src/data/index.js
+++ b/server/src/data/index.js
@@ -21,6 +21,7 @@ module.exports = {
     getOrganisationsByName: require('./getOrganisationsByName'),
     getUserByEmail: require('./getUserByEmail'),
     setImageAsLogoForApp: require('./setImageAsLogoForApp'),
+    patchApp: require('./patchApp'),
     updateApp: require('./updateApp'),
     updateAppVersion: require('./updateAppVersion'),
     updateImageMeta: require('./updateImageMeta'),

--- a/server/src/data/patchApp.js
+++ b/server/src/data/patchApp.js
@@ -1,0 +1,43 @@
+const joi = require('joi')
+
+const paramsSchema = joi
+    .object()
+    .keys({
+        changelog: joi.string().allow('', null),
+        d2config: joi.string().allow('', null),
+        id: joi.string().uuid().required(),
+    })
+    .options({ allowUnknown: false })
+
+/**
+ * Patches an app instance
+ *
+ * @param {object} params
+ * @param {string} params.id id of the app to update
+ * @param {number} params.changelog The changelog of the app
+ * @param {string} params.d2config The latest d2config of the app
+ * @returns {Promise<CreateUserResult>}
+ */
+const patchApp = async (params, knex) => {
+    const validation = paramsSchema.validate(params)
+
+    if (validation.error !== undefined) {
+        throw new Error(validation.error)
+    }
+
+    if (!knex) {
+        throw new Error('Missing parameter: knex')
+    }
+
+    const { id, ...rest } = params
+
+    try {
+        await knex('app').update(rest).where({
+            id,
+        })
+    } catch (err) {
+        throw new Error(`Could not update app: ${id}. ${err.message}`)
+    }
+}
+
+module.exports = patchApp

--- a/server/src/data/patchApp.js
+++ b/server/src/data/patchApp.js
@@ -4,7 +4,6 @@ const paramsSchema = joi
     .object()
     .keys({
         changelog: joi.string().allow('', null),
-        d2config: joi.string().allow('', null),
         id: joi.string().uuid().required(),
     })
     .options({ allowUnknown: false })
@@ -14,8 +13,7 @@ const paramsSchema = joi
  *
  * @param {object} params
  * @param {string} params.id id of the app to update
- * @param {number} params.changelog The changelog of the app
- * @param {string} params.d2config The latest d2config of the app
+ * @param {string} params.changelog The changelog of the app
  * @returns {Promise<CreateUserResult>}
  */
 const patchApp = async (params, knex) => {

--- a/server/src/models/v1/out/App.js
+++ b/server/src/models/v1/out/App.js
@@ -39,6 +39,8 @@ const def = Joi.object().keys({
 
     hasPlugin: Joi.boolean().allow(null, false),
 
+    pluginType: Joi.string().allow(null),
+
     // only indicating if there is a changelog or not here
     // to avoid addding a masssive changelog to the payload
     hasChangelog: Joi.boolean().allow(null, false),

--- a/server/src/models/v1/out/App.js
+++ b/server/src/models/v1/out/App.js
@@ -36,6 +36,12 @@ const def = Joi.object().keys({
         .valid(...AppStatuses),
 
     versions: Joi.array().items(Version).min(1),
+
+    hasPlugin: Joi.boolean().allow(null, false),
+
+    // only indicating if there is a changelog or not here
+    // to avoid addding a masssive changelog to the payload
+    hasChangelog: Joi.boolean().allow(null, false),
 })
 
 module.exports = {

--- a/server/src/models/v1/out/User.js
+++ b/server/src/models/v1/out/User.js
@@ -4,4 +4,5 @@ module.exports = Joi.object().keys({
     address: Joi.string().allow(''),
     email: Joi.string().email(),
     organisation: Joi.string(),
+    organisation_slug: Joi.string(),
 })

--- a/server/src/models/v2/AppVersion.js
+++ b/server/src/models/v2/AppVersion.js
@@ -15,6 +15,7 @@ const definition = defaultDefinition
         maxDhisVersion: Joi.string().allow(null, ''),
         slug: Joi.string(),
         status: Joi.string().valid(...AppStatuses),
+        hasChangelog: Joi.boolean().allow(null),
     })
     .alter({
         db: (s) =>

--- a/server/src/models/v2/Organisation.js
+++ b/server/src/models/v2/Organisation.js
@@ -1,15 +1,29 @@
 const joi = require('../../utils/CustomJoi')
-const User = require('./User')
 const { definition: defaultDefinition } = require('./Default')
 const { createDefaultValidator } = require('./helpers')
+const User = require('./User')
+
+const partialApp = joi.object().keys({
+    type: joi.string(),
+    createdAt: joi.number(),
+    description: joi.string().allow(''),
+    images: joi.any(),
+    id: joi.string(),
+    app_id: joi.string(),
+    name: joi.string(),
+    organisation: joi.any(),
+    hasPlugin: joi.boolean().allow(null, false),
+})
 
 const definition = defaultDefinition
     .append({
         name: joi.string().max(100),
         email: joi.string().email().allow(null),
+        description: joi.string().allow(null),
         slug: joi.string(),
         owner: joi.string().guid({ version: 'uuidv4' }),
         users: joi.array().items(User.definition),
+        apps: joi.array().items(partialApp.options({ allowUnknown: false })),
     })
     .alter({
         db: (s) =>

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -18,6 +18,7 @@ const convertDbAppViewRowToAppApiV1Object = (app) => ({
 
     hasChangelog: app.has_changelog,
     hasPlugin: app.has_plugin,
+    pluginType: app.plugin_type,
     coreApp: app.core_app,
     versions: [],
 

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -15,6 +15,9 @@ const convertDbAppViewRowToAppApiV1Object = (app) => ({
 
     name: app.name,
     description: app.description || '',
+
+    hasChangelog: app.has_changelog,
+    hasPlugin: app.has_plugin,
     coreApp: app.core_app,
     versions: [],
 

--- a/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/server/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -27,6 +27,7 @@ const convertDbAppViewRowToAppApiV1Object = (app) => ({
         address: '',
         email: app.contact_email,
         organisation: app.organisation,
+        organisation_slug: app.organisation_slug,
     },
 
     //TODO: can we use developer_email here ? previous it was oauth token|id

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -129,6 +129,8 @@ module.exports = {
                     appType,
                     status: AppStatus.PENDING,
                     coreApp: isCoreApp,
+                    changelog,
+                    d2config: JSON.stringify(d2config),
                 },
                 trx
             )
@@ -145,8 +147,6 @@ module.exports = {
                     channel,
                     appName: name,
                     description: description || '',
-                    d2config,
-                    changelog,
                 },
                 trx
             )

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -130,7 +130,6 @@ module.exports = {
                     status: AppStatus.PENDING,
                     coreApp: isCoreApp,
                     changelog,
-                    d2config: JSON.stringify(d2config),
                 },
                 trx
             )
@@ -147,6 +146,7 @@ module.exports = {
                     channel,
                     appName: name,
                     description: description || '',
+                    d2config: JSON.stringify(d2config),
                 },
                 trx
             )

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -15,6 +15,7 @@ const {
     verifyBundle,
 } = require('../../../../security')
 
+const parseAppDetails = require('../../../../utils/parseAppDetails')
 const createAppVersion = require('../../../../data/createAppVersion')
 const createLocalizedAppVersion = require('../../../../data/createLocalizedAppVersion')
 const addAppVersionToChannel = require('../../../../data/addAppVersionToChannel')
@@ -136,6 +137,18 @@ module.exports = {
         debug(`Adding version to app ${dbApp.name}`)
         let appVersion = null
 
+        const { changelog, d2config } = await parseAppDetails({
+            buffer: file._data,
+            appRepo: sourceUrl,
+        })
+
+        verifyBundle({
+            buffer: file._data,
+            appId: dbApp.app_id, // null, // this can never be identical on first upload
+            appName: dbApp.name,
+            version,
+        })
+
         try {
             appVersion = await createAppVersion(
                 {
@@ -144,6 +157,8 @@ module.exports = {
                     demoUrl,
                     sourceUrl,
                     version,
+                    changelog,
+                    d2config: JSON.stringify(d2config),
                 },
                 transaction
             )

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -158,6 +158,7 @@ module.exports = {
                     demoUrl,
                     sourceUrl,
                     version,
+                    d2config: JSON.stringify(d2config),
                 },
                 transaction
             )
@@ -167,15 +168,18 @@ module.exports = {
             throw Boom.boomify(err)
         }
 
-        await patchApp(
-            {
-                id: dbApp.app_id,
-                changelog,
-                d2config: JSON.stringify(d2config),
-            },
-            db,
-            transaction
-        )
+        try {
+            await patchApp(
+                {
+                    id: dbApp.app_id,
+                    changelog,
+                },
+                db,
+                transaction
+            )
+        } catch (_) {
+            // ignore if we can not update the changelog at the app level
+        }
 
         //Add the texts as english language, only supported for now
         try {

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -166,9 +166,9 @@ module.exports = [
         config: {
             auth: false,
             tags: ['api', 'v2'],
-            // cache: {
-            //     expiresIn: 24 * 3600 * 1000,
-            // },
+            cache: {
+                expiresIn: 6 * 3600 * 1000,
+            },
             validate: {
                 params: Joi.object({
                     appId: Joi.string().required(),

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -162,6 +162,30 @@ module.exports = [
     },
     {
         method: 'GET',
+        path: '/v2/apps/{appId}/changelog',
+        config: {
+            auth: false,
+            tags: ['api', 'v2'],
+            // cache: {
+            //     expiresIn: 24 * 3600 * 1000,
+            // },
+            validate: {
+                params: Joi.object({
+                    appId: Joi.string().required(),
+                }),
+            },
+        },
+        handler: async (request, h) => {
+            const { db } = h.context
+            const { appVersionService } = request.services(true)
+
+            const { appId } = request.params
+
+            return appVersionService.getChangelog(appId, db)
+        },
+    },
+    {
+        method: 'GET',
         path: '/v2/apps/{appId}/channels',
         config: {
             auth: false,

--- a/server/src/routes/v2/index.js
+++ b/server/src/routes/v2/index.js
@@ -5,5 +5,5 @@ module.exports = [
     require('./me.js'),
     require('./apikey.js'),
     require('./version.js'),
-    require('./appVersions'),
+    require('./appVersions.js'),
 ]

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -48,7 +48,6 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
     const entries = zip.getEntries().map((e) => e.entryName)
     const manifestPath = 'manifest.webapp'
     const d2ConfigPath = 'd2.config.json'
-    const changelogPath = 'CHANGELOG.md'
     const canBeCoreApp = organisationName === 'DHIS2'
 
     if (!entries.includes(manifestPath)) {
@@ -59,7 +58,6 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
         throw new Error(`${manifestPath} is not valid JSON`)
     }
     const manifest = JSON.parse(manifestJson)
-
     checkManifest({
         manifest,
         appId,
@@ -76,9 +74,6 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
     if (!isValidJSON(d2ConfigJson)) {
         throw new Error(`${d2ConfigPath} is not valid JSON`)
     }
-
-    const changeLog = zip.readAsText(changelogPath)
-
     const d2Config = JSON.parse(d2ConfigJson)
     checkD2Config({
         d2Config,
@@ -91,6 +86,5 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
     return {
         manifest,
         d2Config,
-        changeLog,
     }
 }

--- a/server/src/security/verifyBundle.js
+++ b/server/src/security/verifyBundle.js
@@ -48,6 +48,7 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
     const entries = zip.getEntries().map((e) => e.entryName)
     const manifestPath = 'manifest.webapp'
     const d2ConfigPath = 'd2.config.json'
+    const changelogPath = 'CHANGELOG.md'
     const canBeCoreApp = organisationName === 'DHIS2'
 
     if (!entries.includes(manifestPath)) {
@@ -58,6 +59,7 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
         throw new Error(`${manifestPath} is not valid JSON`)
     }
     const manifest = JSON.parse(manifestJson)
+
     checkManifest({
         manifest,
         appId,
@@ -70,9 +72,13 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
         return { manifest }
     }
     const d2ConfigJson = zip.readAsText(d2ConfigPath)
+
     if (!isValidJSON(d2ConfigJson)) {
         throw new Error(`${d2ConfigPath} is not valid JSON`)
     }
+
+    const changeLog = zip.readAsText(changelogPath)
+
     const d2Config = JSON.parse(d2ConfigJson)
     checkD2Config({
         d2Config,
@@ -85,5 +91,6 @@ module.exports = ({ buffer, appId, appName, version, organisationName }) => {
     return {
         manifest,
         d2Config,
+        changeLog,
     }
 }

--- a/server/src/services/app.js
+++ b/server/src/services/app.js
@@ -16,6 +16,8 @@ exports.create = async (
         appType,
         status,
         coreApp,
+        changelog,
+        d2config,
     },
     db
 ) => {
@@ -26,6 +28,8 @@ exports.create = async (
             orgId: organisationId,
             appType: appType,
             coreApp,
+            changelog,
+            d2config,
         },
         db
     )
@@ -55,8 +59,6 @@ exports.createVersionForApp = async (
         channel,
         appName,
         description,
-        d2config,
-        changelog,
     },
     db
 ) => {
@@ -67,8 +69,6 @@ exports.createVersionForApp = async (
             sourceUrl,
             demoUrl,
             version,
-            d2config,
-            changelog,
         },
         db
     )

--- a/server/src/services/app.js
+++ b/server/src/services/app.js
@@ -55,6 +55,8 @@ exports.createVersionForApp = async (
         channel,
         appName,
         description,
+        d2config,
+        changelog,
     },
     db
 ) => {
@@ -65,6 +67,8 @@ exports.createVersionForApp = async (
             sourceUrl,
             demoUrl,
             version,
+            d2config,
+            changelog,
         },
         db
     )

--- a/server/src/services/app.js
+++ b/server/src/services/app.js
@@ -17,7 +17,6 @@ exports.create = async (
         status,
         coreApp,
         changelog,
-        d2config,
     },
     db
 ) => {
@@ -29,7 +28,6 @@ exports.create = async (
             appType: appType,
             coreApp,
             changelog,
-            d2config,
         },
         db
     )
@@ -59,6 +57,7 @@ exports.createVersionForApp = async (
         channel,
         appName,
         description,
+        d2config,
     },
     db
 ) => {
@@ -69,6 +68,7 @@ exports.createVersionForApp = async (
             sourceUrl,
             demoUrl,
             version,
+            d2config,
         },
         db
     )

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -25,6 +25,7 @@ const getAppVersionQuery = (knex) =>
         .select(
             'app_version.id',
             'app_version.version',
+            knex.raw('app_version.changelog<>\'\' as "hasChangelog"'),
             knex.ref('app_version.app_id').as('appId'),
             knex.ref('app_version.created_at').as('createdAt'),
             knex.ref('app_version.updated_at').as('updatedAt'),
@@ -109,6 +110,22 @@ class AppVersionService extends Schmervice.Service {
         const { result } = await executeQuery(query)
 
         return result.map((c) => c.name)
+    }
+
+    async getChangelog(appId, knex) {
+        const query = knex('app_version')
+            .select(
+                'app_version.id',
+                'app_version.version',
+                'app_version.changelog'
+            )
+            .where('app_version.app_id', appId)
+            .where('app_version.changelog', '<>', '')
+        // .distinct()
+
+        const { result } = await executeQuery(query)
+
+        return result
     }
 
     getDownloadUrl(request, appVersion) {

--- a/server/src/services/appVersion.js
+++ b/server/src/services/appVersion.js
@@ -22,10 +22,12 @@ const getAppVersionQuery = (knex) =>
             'app_version.app_id'
         )
         .innerJoin(knex.ref('channel'), 'ac.channel_id', 'channel.id')
+        .innerJoin(knex.ref('app'), 'app.id', 'app_version.app_id')
+
         .select(
             'app_version.id',
             'app_version.version',
-            knex.raw('app_version.changelog<>\'\' as "hasChangelog"'),
+            knex.raw('app.changelog<>\'\' as "hasChangelog"'),
             knex.ref('app_version.app_id').as('appId'),
             knex.ref('app_version.created_at').as('createdAt'),
             knex.ref('app_version.updated_at').as('updatedAt'),
@@ -113,15 +115,9 @@ class AppVersionService extends Schmervice.Service {
     }
 
     async getChangelog(appId, knex) {
-        const query = knex('app_version')
-            .select(
-                'app_version.id',
-                'app_version.version',
-                'app_version.changelog'
-            )
-            .where('app_version.app_id', appId)
-            .where('app_version.changelog', '<>', '')
-        // .distinct()
+        const query = knex('app')
+            .first('app.id', 'app.changelog')
+            .where('app.id', appId)
 
         const { result } = await executeQuery(query)
 

--- a/server/src/services/organisation.js
+++ b/server/src/services/organisation.js
@@ -5,15 +5,18 @@ const { NotFoundError } = require('../utils/errors')
 const { slugify } = require('../utils/slugify')
 
 const getOrganisationQuery = (db) =>
-    db('organisation').select(
-        'organisation.id',
-        'organisation.name',
-        'organisation.email',
-        'organisation.slug',
-        'organisation.created_by_user_id',
-        'organisation.updated_at',
-        'organisation.created_at'
-    )
+    db('organisation')
+        .select(
+            'organisation.id',
+            'organisation.name',
+            'organisation.email',
+            'organisation.slug',
+            'organisation.description',
+            'organisation.created_by_user_id',
+            'organisation.updated_at',
+            'organisation.created_at'
+        )
+        .orderBy('organisation.name')
 
 const checkSlugExists = async (slug, knex) => {
     const slugMatch = await knex('organisation')
@@ -110,6 +113,25 @@ const findOneBySlug = async (slug, includeUsers = false, knex) => {
     return findOneByColumn(slug, { columnName: 'slug', includeUsers }, knex)
 }
 
+const getAppsInOrganisation = async (orgSlug, knex) => {
+    return knex('apps_view')
+        .innerJoin(
+            'organisation',
+            'organisation.slug',
+            'apps_view.organisation_slug'
+        )
+        .distinct('app_id')
+        .select(
+            'apps_view.*',
+            'apps_view.description',
+            'apps_view.name',
+            // 'apps_view.*',
+            'apps_view.has_plugin as hasPlugin',
+            'organisation.name as organisation_name'
+        )
+        .where('organisation_slug', orgSlug)
+}
+
 const getUsersInOrganisation = async (orgId, knex) => {
     const users = await knex('users')
         .select('users.id', 'users.email', 'users.name')
@@ -198,6 +220,7 @@ module.exports = {
     find,
     findOne,
     findOneBySlug,
+    getAppsInOrganisation,
     addUserById,
     create,
     update,

--- a/server/src/utils/parseAppDetails.js
+++ b/server/src/utils/parseAppDetails.js
@@ -4,28 +4,31 @@ const request = require('request-promise-native')
 
 const getChangeLog = async (appRepo) => {
     debug(`Getting changelog from: ${appRepo}`)
-    try {
+    const possibleBranches = ['master', 'main']
+
+    for (const branch of possibleBranches) {
         const targetUrl =
             appRepo
                 ?.replace(/\/$/, '')
                 ?.replace(
                     'https://github.com',
                     'https://raw.githubusercontent.com'
-                ) + '/refs/heads/master/CHANGELOG.md' // todo: check main branch as well?
+                ) + `/refs/heads/${branch}/CHANGELOG.md`
 
-        if (!targetUrl) {
-            return null
-        }
         debug(`Getting changelog from: ${targetUrl}`)
-        const response = await request.get({
-            url: targetUrl,
-            contentType: 'plain/text',
-        })
-        return response
-    } catch (err) {
-        console.error(err)
-        return null
+
+        try {
+            const response = await request.get({
+                url: targetUrl,
+                contentType: 'plain/text',
+            })
+            return response
+        } catch (err) {
+            console.error(err)
+        }
     }
+
+    return null
 }
 
 module.exports = async ({ buffer, appRepo }) => {

--- a/server/src/utils/parseAppDetails.js
+++ b/server/src/utils/parseAppDetails.js
@@ -7,12 +7,15 @@ const getChangeLog = async (appRepo) => {
     try {
         const targetUrl =
             appRepo
-                .replace(/\/$/, '')
-                .replace(
+                ?.replace(/\/$/, '')
+                ?.replace(
                     'https://github.com',
                     'https://raw.githubusercontent.com'
-                ) + '/refs/heads/main/CHANGELOG.md'
+                ) + '/refs/heads/master/CHANGELOG.md' // todo: check main branch as well?
 
+        if (!targetUrl) {
+            return null
+        }
         debug(`Getting changelog from: ${targetUrl}`)
         const response = await request.get({
             url: targetUrl,
@@ -42,17 +45,15 @@ module.exports = async ({ buffer, appRepo }) => {
             }
         }
 
-        const d2Config = JSON.parse(d2ConfigJson)
+        const d2config = JSON.parse(d2ConfigJson)
 
         return {
-            d2Config,
+            d2config,
             changelog,
         }
     } catch (err) {
-        // throw err
-        // console.error(err)
         return {
-            d2Config: null,
+            d2config: null,
             changelog: null,
         }
     }

--- a/server/src/utils/parseAppDetails.js
+++ b/server/src/utils/parseAppDetails.js
@@ -1,0 +1,59 @@
+const AdmZip = require('adm-zip')
+const debug = require('debug')('apphub:server:create-app-version')
+const request = require('request-promise-native')
+
+const getChangeLog = async (appRepo) => {
+    debug(`Getting changelog from: ${appRepo}`)
+    try {
+        const targetUrl =
+            appRepo
+                .replace(/\/$/, '')
+                .replace(
+                    'https://github.com',
+                    'https://raw.githubusercontent.com'
+                ) + '/refs/heads/main/CHANGELOG.md'
+
+        debug(`Getting changelog from: ${targetUrl}`)
+        const response = await request.get({
+            url: targetUrl,
+            contentType: 'plain/text',
+        })
+        return response
+    } catch (err) {
+        console.error(err)
+        return null
+    }
+}
+
+module.exports = async ({ buffer, appRepo }) => {
+    try {
+        const zip = new AdmZip(buffer)
+        const d2ConfigPath = 'd2.config.json'
+        const changelogPath = 'CHANGELOG.md'
+
+        const d2ConfigJson = zip.readAsText(d2ConfigPath)
+
+        let changelog = zip.readAsText(changelogPath)
+
+        if (!changelog) {
+            const result = await getChangeLog(appRepo)
+            if (result) {
+                changelog = result
+            }
+        }
+
+        const d2Config = JSON.parse(d2ConfigJson)
+
+        return {
+            d2Config,
+            changelog,
+        }
+    } catch (err) {
+        // throw err
+        // console.error(err)
+        return {
+            d2Config: null,
+            changelog: null,
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,7 +3262,7 @@
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.12.1":
+"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.14.1.tgz#a9f6a07f2b03c95c8d38c4536a1fdfb521ff55b6"
   integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
@@ -3328,7 +3328,7 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.13.2.tgz#917a20e93f71ad5602966c2d685ae0c6c21f60f1"
   integrity sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==
 
-"@webassemblyjs/wasm-edit@^1.12.1":
+"@webassemblyjs/wasm-edit@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz#ac6689f502219b59198ddec42dcd496b1004d597"
   integrity sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==
@@ -3363,7 +3363,7 @@
     "@webassemblyjs/wasm-gen" "1.14.1"
     "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.12.1":
+"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz#b3e13f1893605ca78b52c68e54cf6a865f90b9fb"
   integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
@@ -3602,9 +3602,9 @@ ansi-regex@^4.1.0:
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-regex@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -6953,7 +6953,12 @@ ftp@^0.3.10:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
-function-bind@^1.1.1, function-bind@^1.1.2:
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
@@ -7725,12 +7730,12 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@1.1.13:
+ieee754@1.1.13, ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
+ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -8000,20 +8005,26 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.13.0, is-core-module@^2.13.1, is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.6.0:
+is-core-module@^2.13.0, is-core-module@^2.13.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.1.tgz#a7363a25bee942fefab0de13bf6aa372c82dcc37"
   integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
   dependencies:
     hasown "^2.0.2"
 
-is-data-descriptor@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.5.tgz#0907e763b9989b5b01c10a5aa5d09469bbae392e"
-  integrity sha512-a7ZgE8u0mkmoWpRMbmuwFQRFa2IFNcbG4eR+iqMYghjMTdXYitWgttZCxGit7zCc98gvO1TvOF0sSEZuZEvbPQ==
+is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.6.0, is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
   dependencies:
-    gopd "^1.0.1"
-    hasown "^2.0.0"
+    has "^1.0.3"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
+  integrity "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg== sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg=="
+  dependencies:
+    kind-of "^3.0.2"
 
 is-data-descriptor@^1.0.0:
   version "1.0.0"
@@ -8049,8 +8060,8 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 
 is-directory@^0.3.1:
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
-  integrity sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==
+  resolved "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz"
+  integrity "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw== sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw=="
 
 is-docker@^3.0.0:
   version "3.0.0"
@@ -8059,8 +8070,8 @@ is-docker@^3.0.0:
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+  integrity "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw== sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
 
 is-extendable@^1.0.1:
   version "1.0.1"
@@ -8086,18 +8097,18 @@ is-fullwidth-code-point@^2.0.0:
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator@^1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-generator/-/is-generator-1.0.3.tgz#c14c21057ed36e328db80347966c693f886389f3"
-  integrity sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==
+  resolved "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz"
+  integrity "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA==sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA== sha512-G56jBpbJeg7ds83HW1LuShNs8J73Fv3CPz/bmROHOHlnKkN8sWb9ujiagjmxxMUywftgq48HlBZELKKqFLk0oA=="
 
 is-glob@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
-  integrity sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+  integrity "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg== sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg=="
   dependencies:
     is-extglob "^1.0.0"
 
@@ -9063,8 +9074,8 @@ lru-memoizer@^2.1.2, lru-memoizer@^2.1.4:
 
 lru_map@^0.3.3:
   version "0.3.3"
-  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
-  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+  resolved "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz"
+  integrity "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ== sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -9075,7 +9086,7 @@ make-dir@^1.0.0:
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
   dependencies:
     pify "^4.0.1"
@@ -9525,6 +9536,11 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 mini-create-react-context@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz"
@@ -9543,14 +9559,14 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg== sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
 
-minimatch@3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.2:
+minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -9692,12 +9708,12 @@ ms@2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A== sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 
-ms@2.1.2:
+ms@2.1.2, ms@^2.1.1, ms@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -10114,8 +10130,8 @@ os-browserify@~0.3.0:
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+  integrity "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g== sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
 
 outpipe@^1.1.0:
   version "1.1.1"
@@ -11481,7 +11497,16 @@ resolve@^1.1.4, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^2.0.0-next.4, resolve@^2.0.0-next.5:
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^2.0.0-next.5:
   version "2.0.0-next.5"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.5.tgz#6b0ec3107e671e52b68cd068ef327173b90dc03c"
   integrity sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==
@@ -11584,12 +11609,12 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -11620,19 +11645,19 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@1.2.1:
+sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
   integrity "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA== sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
 
-sax@>=0.6.0, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  resolved "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz"
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
@@ -11724,29 +11749,34 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1, semver@^5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.5:
+semver@7.3.5, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8:
+semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -12500,22 +12530,22 @@ strip-indent@^3.0.0:
 
 strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+  integrity "sha1-PFMZQukIwml8DsNEhYwobHygpgo=sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ== sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
 
 style-loader@^3.2.1:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.4.tgz#f30f786c36db03a45cbd55b6a70d930c479090e7"
-  integrity sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz"
+  integrity sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==
 
 style-to-object@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
+  resolved "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz"
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
   dependencies:
     inline-style-parser "0.1.1"
@@ -13002,15 +13032,15 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tslib@~2.1.0:
+tslib@^2.0.1, tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tty-browserify@0.0.1:
   version "0.0.1"
@@ -13717,15 +13747,15 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.96.1:
-  version "5.96.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.96.1.tgz#3676d1626d8312b6b10d0c18cc049fba7ac01f0c"
-  integrity sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==
+  version "5.97.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.97.0.tgz#1c5e3b9319f8c6decb19b142e776d90e629d5c40"
+  integrity sha512-CWT8v7ShSfj7tGs4TLRtaOLmOCPWhoKEvp+eA7FVx8Xrjb3XfT0aXdxDItnRZmE8sHcH+a8ayDrJCOjXKxVFfQ==
   dependencies:
     "@types/eslint-scope" "^3.7.7"
     "@types/estree" "^1.0.6"
-    "@webassemblyjs/ast" "^1.12.1"
-    "@webassemblyjs/wasm-edit" "^1.12.1"
-    "@webassemblyjs/wasm-parser" "^1.12.1"
+    "@webassemblyjs/ast" "^1.14.1"
+    "@webassemblyjs/wasm-edit" "^1.14.1"
+    "@webassemblyjs/wasm-parser" "^1.14.1"
     acorn "^8.14.0"
     browserslist "^4.24.0"
     chrome-trace-event "^1.0.2"


### PR DESCRIPTION
This adds functionality to show the changelog in the UI and visually differentiate plugins in the list of apps. Implements [HUB-156](https://dhis2.atlassian.net/browse/HUB-156) and [HUB-144](https://dhis2.atlassian.net/browse/HUB-144).

From a UX perspective, both these functionalities will be improved in upcoming tickets, but this PR sets the ground for how we do it, while exposing a very basic UI to test the functionality.

**After a first discussion, we decided to move `d2config` and `changelog` columns to the `app` table instead of `appeversion` - in addition, we added a `change_summary` column to versions table that would allow users to highlight what changed in a specific version. The `d2config` is taken from the uploaded zip file - while we attempt to get the change log from the zip file or the GitHub source url. Once we have the full change log - if we have it - we can display it in the UI in numerous ways, for now, we just implemented the simplest solution to show the full change log**
 
The workflow is as follows:

- When uploading a new version or a new app, we save the `d2.config.js`  (as a JSON type) and `CHANGELOG.md` to the `app` table.
   - If we're uploading a new version, we _patch_ the app entry with the `d2config` and `changelog` from the last version.
   - This means we only have the last version of these files - this is ok because this is the information we'd be interested in in this context, i.e. an app will be shown as a "plugin" if the latest d2config has a plugin entry, it doesn't matter if it did or did not have such an entry in the past. The same for the changelog - with the addition that we can infer all history from one (good) changelog and we also didn't want to have a massive text file saved with each version unnecessarily  
- An indicator `has_plugin` is added to the `app_view` view.  `has_plugin` inspects the JSON type and returns a flag whether a plugin entry point is found or not. This is returned to `/apps` endpoint and `/apps/:id`.
   - the whole `d2config` - rather than just the plugin info - is saved as it could be used to infer other information (i.e offline support, RTL support etc..).
   - if / when the entryPoints logic change (for example, to have multiple plugins), then the logic in the view can be updated.
- Both `d2.config` and `changelog.md` are not returned fully as part of apps or appversions endpoints - only an indicator that they exist, or inferred info (i.e. `has_plugins`)
 - A separate endpoint to get the changelog is added `/apps/:id/changelog`. It is separate to avoid returning a potentially large text file in the apps or apps/:id response. We only return an indicator, which the UI can use to show a "view changes" button, and when that is clicked, it calls the API and returns the changelog.
    - The changelog returned is for the app - that is all the app versions for that app. The UI, then, can make decisions based on that - for example, one changelog from a different version likely includes the changes from previous versions too. This minimises the need to have a script to backfill old versions change logs, as once a new version is added - it will contain  all the changes for previous versions too (at least for apps that follow conventional change logs, like our internal apps), but it needs to be limited as well potentially as more versions with changelogs are added
- We look for the changelog in the uploaded version zip file - in most cases (in our apps), it's not part of the bundle though. So we also  _try_ and get the changelog from the app github url if that exists.
   - This is pretty crude at the moment, for example, it works with changelogs in master branch only (might add a second check for main branch)
   - There is also a new field `change_summary` added to the version table where users can just highlight what changed in a specific version manually - this is not exposed yet in the UI.


## ToDO :
- I have a script to backfill previously added apps (by reading d2config and changelog) from GitHub - still undecided if we need to do that or not. With the current approach, we will get the changelog once a new version is uploaded, so it doesn't seem like this 
- [future] add ability to manually input a "what changed section" to the version info. This is the `change_summary_ field in the versions table, and can be used along the change log or instead of it. 

## UX
The UX, especially for the Changelog, is a placeholder - once we have the changelog info, we can parse and display as we want. I want a simple version in first, and that we agree on the database and API structure.

But here are some UX questions that came to mind while working on this:
- now that there is a "plugin" tag, it makes the "Standard" tag less obvious - shall we change that to a Tag too? what does "standard" even mean?
- how to filter plugins? right now, I added a "backdoor" where the user can search the word "plugin" and that will show all plugins
- how to word the fact that an app is a a plugin - technically it _has_ a plugin (or multiple plugins), but it is can also be an app
- ....

## Screenshots

![image](https://github.com/user-attachments/assets/3de2e825-02c7-4721-b5a7-2ea6313d5a0c)

![image](https://github.com/user-attachments/assets/f2d34399-24e1-475c-9f02-9de552a1fa62)

![image](https://github.com/user-attachments/assets/b6d671aa-0e56-4177-98b3-daf5e1eb994a)





[HUB-156]: https://dhis2.atlassian.net/browse/HUB-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HUB-144]: https://dhis2.atlassian.net/browse/HUB-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ