### PR TITLE
fix: increase max bundle size to 40MB

### DIFF
--- a/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,1 +1,1 @@
-client_max_body_size 20M;
+client_max_body_size 40M;

--- a/server/src/routes/v1/apps/handlers/createApp.js
+++ b/server/src/routes/v1/apps/handlers/createApp.js
@@ -22,7 +22,7 @@ module.exports = {
         auth: 'token',
         tags: ['api', 'v2'],
         payload: {
-            maxBytes: 20 * 1024 * 1024, //20MB
+            maxBytes: 40 * 1024 * 1024, //40MB
             allow: 'multipart/form-data',
             parse: true,
             output: 'stream',

--- a/server/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/server/src/routes/v1/apps/handlers/createAppVersion.js
@@ -38,7 +38,7 @@ module.exports = {
         },
         tags: ['api', 'v1'],
         payload: {
-            maxBytes: 20 * 1024 * 1024, //20MB
+            maxBytes: 40 * 1024 * 1024, //40MB
             allow: 'multipart/form-data',
             parse: true,
             output: 'stream',

--- a/server/src/routes/v2/apps.js
+++ b/server/src/routes/v2/apps.js
@@ -87,7 +87,7 @@ module.exports = [
             auth: 'token',
             tags: ['api', 'v2'],
             payload: {
-                maxBytes: 20 * 1024 * 1024, //20MB
+                maxBytes: 40 * 1024 * 1024, //40MB
                 allow: 'multipart/form-data',
                 parse: true,
                 output: 'stream',


### PR DESCRIPTION
This increase is needed for the new version of `@dhis2/data-visualizer-app`.

In order to support client-side PDF export of charts with non-latin characters I have add a shedload of `.ttf` files to the `./public` folder. Any given user only needs one of these files and they are not downloaded until they actually use the export functionality, so the app's load-time is unaffected but the app's bundle size has exploded quite a bit. So much so that the app-hub was refusing it ([see here](https://github.com/dhis2/data-visualizer-app/actions/runs/15142637326/job/42570483879#step:7:18)) 

These changes should allow for the app to be published to app-hub successfully.