### PR TITLE
fix(DHIS2-19851): show "stable" version as latest version to download

### DIFF
--- a/client/src/pages/AppView/AppView.js
+++ b/client/src/pages/AppView/AppView.js
@@ -211,7 +211,8 @@ const AppView = ({ match }) => {
     const logoSrc = app.images.find((img) => img.logo)?.imageUrl
     const screenshots = app.images.filter((img) => !img.logo)
     const versions = app.versions.sort((a, b) => b.created - a.created)
-    const latestVersion = versions[0]
+    const stableVersions = versions.filter((v) => v.channel === 'stable')
+    const latestVersion = stableVersions?.[0] ?? versions[0]
 
     const selectTab = (tabName) => () => {
         history.push('?tab=' + tabName)
@@ -263,7 +264,10 @@ const AppView = ({ match }) => {
                             latestVersion={latestVersion}
                             sourceUrl={app.sourceUrl}
                         />
-                        <LatestUpdates changelog={changelog?.data} />
+                        <LatestUpdates
+                            versions={versions}
+                            changelog={changelog?.data}
+                        />
                     </>
                 )}
 

--- a/client/src/pages/AppView/LatestUpdates.js
+++ b/client/src/pages/AppView/LatestUpdates.js
@@ -1,19 +1,32 @@
+import PropTypes from 'prop-types'
 import ReactMarkdown from 'react-markdown'
 import { useHistory } from 'react-router-dom'
 import styles from './LatestUpdates.module.css'
 
-export const LatestUpdates = ({ changelog }) => {
+export const LatestUpdates = ({ versions, changelog }) => {
     const history = useHistory()
     if (!changelog) {
         return null
     }
+
+    const versionsToShow = changelog.filter(
+        ({ version }) =>
+            !!versions.find(
+                (v) => v.version === version && v.channel === 'stable'
+            )
+    )
+
+    if (versionsToShow?.length === 0) {
+        return null
+    }
+
     return (
         <div className={styles.latestUpdatesWrapper}>
             <div className={styles.latestUpdates}>
                 <h2 className={styles.latestUpdatesHeader}>Latest updates:</h2>
 
                 <ol className={styles.versionList}>
-                    {changelog?.slice(0, 3).map((version, i) => {
+                    {versionsToShow?.slice(0, 3).map((version, i) => {
                         return (
                             <li key={version.version}>
                                 <h3
@@ -43,4 +56,9 @@ export const LatestUpdates = ({ changelog }) => {
             </div>
         </div>
     )
+}
+
+LatestUpdates.propTypes = {
+    changelog: PropTypes.object,
+    versions: PropTypes.array,
 }

--- a/client/src/pages/UserAppEdit/DescriptionEditor.js
+++ b/client/src/pages/UserAppEdit/DescriptionEditor.js
@@ -53,6 +53,7 @@ const DescriptionEditor = ({
                 hidden={selectedTab !== tabs.WRITE}
                 name={name}
                 helpText={helpText}
+                required={required}
             />
             {selectedTab === tabs.PREVIEW && <PreviewContent name={name} />}
             <Help className={styles.helpText}>
@@ -72,15 +73,14 @@ DescriptionEditor.propTypes = {
     required: PropTypes.bool,
 }
 
-const WriteContent = ({ description, name, placeholder, hidden }) => {
+const WriteContent = ({ description, name, placeholder, hidden, required }) => {
     return (
         <div className={cx(styles.writeContent, { [styles.hidden]: hidden })}>
             <MarkdownEditor
                 name={name ?? 'description'}
                 initialValue={description}
-                validate={hasValue}
+                validate={required ? hasValue : null}
                 placeholder={placeholder ?? 'What is the purpose of this app?'}
-                required
             />
         </div>
     )
@@ -91,6 +91,7 @@ WriteContent.propTypes = {
     hidden: PropTypes.bool,
     name: PropTypes.string,
     placeholder: PropTypes.string,
+    required: PropTypes.bool,
 }
 
 const PreviewContent = ({ name = 'description' }) => {

--- a/server/src/models/v1/out/App.js
+++ b/server/src/models/v1/out/App.js
@@ -40,7 +40,7 @@ const def = Joi.object().keys({
     hasPlugin: Joi.boolean().allow(null, false),
 
     // only indicating if there is a changelog or not here
-    // to avoid addding a masssive changelog to the payload
+    // to avoid adding a massive changelog to the payload
     hasChangelog: Joi.boolean().allow(null, false),
 
     pluginType: Joi.string().allow(null),


### PR DESCRIPTION
This fix ensures that the "stable" version of an app, rather than development or canary version, is shown as the latest version to download. It also ensures that "Latest Updates" section shows the stable versions.

- In addition, it fixes an unrelated issue with the "change summary" field being mandatory when uploading a new version.

fixes https://dhis2.atlassian.net/browse/HUB-169