### PR TITLE
fix: change page size for versions

### DIFF
--- a/client/src/components/Versions/Versions.js
+++ b/client/src/components/Versions/Versions.js
@@ -51,7 +51,7 @@ const Versions = ({
     const [dhisVersionFilter, setDhisVersionFilter] = useState('-1')
     const params = useMemo(
         () => ({
-            pageSize: 5,
+            pageSize: 50,
             minDhisVersion:
                 dhisVersionFilter != '-1'
                     ? `lte:${dhisVersionFilter}`


### PR DESCRIPTION
This increases the default page size for the versions list. 

The reason is to provide a workaround for deep links to a specific version, i.e. `https://apps.dhis2.org/app/92b75fd0-34cc-451c-942f-3dd0f283bcbd?tab=previous-releases#103.1.3` which wouldn't work if the linked version is not loaded, and needs to be lazily loaded by clicking "load more". 

`50` is a bit of a random value (although `5` is very low I would say) to cater for the specific case from [Capture app](https://dhis2.slack.com/archives/C07A1DURSUA/p1756394763416269). The performance implication is minimal - if we load all releases (pageSize=1000 which loads all the 493 capture releases), which is the most extreme scenario, this makes the request ~23KB as opposed to 3KB (and it takes 170 ms as opposed to 60ms) ... I don't think that difference is relevant for the scale and load of AppHub. So eventually, we can just load all releases, and do paging on the client-side for UX reasons if we'd like to. For now, a larger value is an OK workaround with minimal implications.



